### PR TITLE
Default Logging Configuration And Fixture Refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /home/lfh
 COPY --chown=lfh:lfh ./pyconnect ./pyconnect
 COPY --chown=lfh:lfh ./setup.py setup.py
 COPY --chown=lfh:lfh ./README.md README.md
+COPY --chown=lfh:lfh ./logging.yaml logging.yaml
 RUN pip install --user -e .
 
 CMD ["python", "/home/lfh/pyconnect/main.py"]

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,0 +1,19 @@
+version: 1
+disable_existing_loggers: false
+formatters:
+  simple:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: simple
+    stream: ext://sys.stdout
+root:
+  level: WARN
+  handlers: [console]
+loggers:
+  uvicorn.access:
+    level: INFO
+    handlers: [console]
+    propogate: no

--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -17,6 +17,8 @@ class Settings(BaseSettings):
     """
     pyconnect application settings
     """
+    # logging
+    logging_config_path: str = 'logging.yaml'
     # uvicorn settings
     uvicorn_cert: str
     uvicorn_cert_key: str

--- a/pyconnect/main.py
+++ b/pyconnect/main.py
@@ -5,11 +5,18 @@ Bootstraps the Fast API application and Uvicorn processes
 """
 from fastapi import FastAPI
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
+import uvicorn
+import logging.config
+import os
+import yaml
+import sys
+from yaml.error import YAMLError
 from pyconnect.config import get_settings
 from pyconnect.routes import (data,
                               status)
 from pyconnect import __version__
-import uvicorn
+
+settings = get_settings()
 
 
 def get_app() -> FastAPI:
@@ -30,9 +37,35 @@ def get_app() -> FastAPI:
 
 app = get_app()
 
-if __name__ == '__main__':
-    settings = get_settings()
 
+@app.on_event('startup')
+def configure_logging():
+    """
+    Configures logging for the pyconnect application.
+    Logging configuration is parsed from the setting/environment variable LOGGING_CONFIG_PATH, if present.
+    If LOGGING_CONFIG_PATH is not found, a basic config is applied.
+    """
+    def apply_basic_config():
+        """Applies a basic config for console logging"""
+        logging.basicConfig(stream=sys.stdout,
+                            level=logging.INFO,
+                            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    if os.path.exists(settings.logging_config_path):
+        with open(settings.logging_config_path, 'r') as f:
+            try:
+                logging_config = yaml.safe_load(f)
+                logging.config.dictConfig(logging_config)
+            except YAMLError as e:
+                apply_basic_config()
+                logging.error(f'Unable to load logging configuration from file: {e}.')
+                logging.info('Applying basic logging configuration.')
+    else:
+        apply_basic_config()
+        logging.info('Logging configuration not found. Applying basic logging configuration.')
+
+
+if __name__ == '__main__':
     uvicorn_params = {
         'app': settings.uvicorn_app,
         'host': settings.uvicorn_host,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setuptools.setup(
     install_requires=[
         'fastapi==0.63.0',
         'uvicorn==0.13.3',
-        'requests==2.25.1'
+        'requests==2.25.1',
+        'pyaml==20.4.0'
     ],
     extras_require={
         'test': ['pytest==6.1.2'],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-from pyconnect.main import app
-from fastapi.testclient import TestClient
-
-client = TestClient(app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ conftest.py
 Contains global/common pytest fixtures
 """
 from pyconnect.config import Settings
+from fastapi.testclient import TestClient
 import pytest
 
 
@@ -18,3 +19,16 @@ def settings() -> Settings:
         'uvicorn_cert': './mycert.pem'
     }
     return Settings(**settings_fields)
+
+
+@pytest.fixture
+def test_client(monkeypatch) -> TestClient:
+    """
+    Creates a Fast API Test Client for API testing
+    :param monkeypatch: monkeypatch fixture
+    :return: Fast API test client
+    """
+    monkeypatch.setenv('UVICORN_CERT', './mycert.pem')
+    monkeypatch.setenv('UVICORN_CERT_KEY', './mycert.key')
+    from pyconnect.main import app
+    return TestClient(app)

--- a/tests/routes/test_data.py
+++ b/tests/routes/test_data.py
@@ -2,19 +2,18 @@
 test_data.py
 Tests /data endpoints
 """
-from tests import client
 
 
-def test_get_data_record():
+def test_get_data_record(test_client):
     """
     Tests /data?dataFormat=x&partition=0&offset=0
     """
-    actual_response = client.get('/data',
-                                 params={
-                                     'dataformat': 'EXAMPLE',
-                                     'partition': 100,
-                                     'offset': 4561
-                                 })
+    actual_response = test_client.get('/data',
+                                      params={
+                                          'dataformat': 'EXAMPLE',
+                                          'partition': 100,
+                                          'offset': 4561
+                                      })
     assert actual_response.status_code == 200
 
     actual_json = actual_response.json()

--- a/tests/routes/test_data.py
+++ b/tests/routes/test_data.py
@@ -7,6 +7,7 @@ Tests /data endpoints
 def test_get_data_record(test_client):
     """
     Tests /data?dataFormat=x&partition=0&offset=0
+    :param test_client: Fast API test client
     """
     actual_response = test_client.get('/data',
                                       params={

--- a/tests/routes/test_status.py
+++ b/tests/routes/test_status.py
@@ -2,17 +2,17 @@
 test_status.py
 Tests the /status API endpoints
 """
-from tests import client
 from pyconnect.config import get_settings
 
 
-def test_status_get(settings):
+def test_status_get(test_client, settings):
     """
     Tests /status [GET]
+    :param test_client: Fast API test client
     :param settings: Settings test fixture
     """
-    client.app.dependency_overrides[get_settings] = lambda: settings
-    actual_response = client.get('/status')
+    test_client.app.dependency_overrides[get_settings] = lambda: settings
+    actual_response = test_client.get('/status')
     assert actual_response.status_code == 200
 
     actual_json = actual_response.json()


### PR DESCRIPTION
resolves #22 

This PR adds a default logging configuration, logging.yaml, to the project. The logging configuration provides the following "out of the box"

- A console/stdout appender
- root logger set to WARNING
- A logging configuration for the uvicorn.access package to support HTTP request logging
- A pyconnect configuration/environment variable for the logging configuration. We can override this setting as needed to support running in a container, pod, etc.

The uvicorn.access package will log ALL inbound requests, including the requests made by the Open API UI.

Sample Output
```shell
(venv) tdw@dixons-mbp pyconnect % UVICORN_CERT=./local-certs/server.crt UVICORN_CERT_KEY=./local-certs/server.key UVICORN_RELOAD=True python pyconnect/main.py
INFO:     Uvicorn running on https://0.0.0.0:5000 (Press CTRL+C to quit)
INFO:     Started reloader process [6680] using statreload
INFO:     Started server process [6683]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
2021-02-15 22:33:45,674 - uvicorn.error - INFO - Application startup complete.
2021-02-15 22:33:55,645 - uvicorn.access - INFO - 127.0.0.1:56236 - "GET /status HTTP/1.1" 200
```

If you need to enable logging within a specific python module . . .
```python
import logging
logger = logging.getLogger(__name__)
logger.info('msg')
```

[Python logging documentation](https://docs.python.org/3/howto/logging.html#)

Update: This PR also refactors the Fast API test client to be a pytest "fixture" rather than a "global" test package attribute. I made this change to address issues with some local test errors.