### PR TITLE
Refine profiles. Have only 1 profile for deploying IPFS additionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,17 @@ openssl rand -hex 32
 ```
 
 #### Start supporting services and pyconnect
-- To start services without IPFS support, please use the `dev` profile.
-- To add IPFS support use the `ipfs` profile.
 ```shell
-docker-compose --profile dev up -d
+docker-compose up -d
 docker-compose ps
 PYCONNECT_CERT=./local-certs/lfh.pem \
   PYCONNECT_CERT_KEY=./local-certs/lfh.key \
   UVICORN_RELOAD=True \
   python pyconnect/main.py 
+```
+- To add IPFS support use the `ipfs` profile.
+```
+docker-compose --profile ipfs up -d
 ```
 
 Browse to `https://localhost:5000/docs` to view the Open API documentation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ networks:
       driver: default
 services:
   nats-server:
-    profiles: ["dev","ipfs"]
     networks:
       - main
     image: docker.io/linuxforhealth/jetstream:v0.0.19
@@ -21,12 +20,10 @@ services:
     ports:
       - "4222:4222"
   zookeeper:
-    profiles: ["dev","ipfs"]
     networks:
       - main
     image: docker.io/linuxforhealth/zookeeper-alpine:3.6.2
   kafka:
-    profiles: ["dev","ipfs"]
     networks:
       - main
     image: docker.io/linuxforhealth/kafka-alpine:2.5.0
@@ -50,10 +47,10 @@ services:
       CLUSTER_SECRET: 724931756d306e6d56685055714966347373424e77484d733369575433364d42
       CLUSTER_IPFSHTTP_NODEMULTIADDRESS: /dns4/ipfs-node-0/tcp/5001
       CLUSTER_CRDT_TRUSTEDPEERS: '*' # Trust all peers in Cluster
-#       CLUSTER_RESTAPI_HTTPLISTENMULTIADDRESS: /ip4/127.0.0.1/tcp/9094 # Expose API
+#     CLUSTER_RESTAPI_HTTPLISTENMULTIADDRESS: /ip4/127.0.0.1/tcp/9094 # Expose API
       CLUSTER_MONITORPINGINTERVAL: 2s # Speed up peer discovery
-#     ports:
-#       - "127.0.0.1:9094:9094"
+#   ports:
+#     - "127.0.0.1:9094:9094"
     volumes:
       - ./ipfs-cluster-0/config:/data/ipfs-cluster
   ipfs-node-0:


### PR DESCRIPTION
Refine profiles as outlined in https://github.com/LinuxForHealth/pyconnect/issues/35. 

We do not need to have profiles for default services that are required to be deployed. With this PR, we removed the `dev` profile that was needed earlier to deploy Kafka, Zookeeper and NATS.

We are down to only having a single `ipfs` profile that can deploy IPFS Peer and Cluster nodes in addition to the default services.
```
docker-compose --profile ipfs up -d
```