### PR TITLE
SSL and Formatting Adjustments

### DIFF
--- a/pyconnect/clients.py
+++ b/pyconnect/clients.py
@@ -6,7 +6,6 @@ Services instances are bound to data attributes and accessed through "get" funct
 """
 import asyncio
 import confluent_kafka
-import ssl
 from confluent_kafka import KafkaException
 from nats.aio.client import Client as NatsClient
 from threading import Thread
@@ -97,15 +96,9 @@ async def get_nats_client() -> Optional[NatsClient]:
 
     if not nats_client:
         settings = get_settings()
-
-        ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
-        ssl_ctx.load_verify_locations(settings.nats_rootCA_file)
-        ssl_ctx.load_cert_chain(settings.nats_cert_file, settings.nats_key_file)
-
         nats_client = NatsClient()
         await nats_client.connect(
             servers=settings.nats_servers,
-            tls=ssl_ctx,
             allow_reconnect=settings.nats_allow_reconnect,
             max_reconnect_attempts=settings.nats_max_reconnect_attempts)
 

--- a/pyconnect/exceptions.py
+++ b/pyconnect/exceptions.py
@@ -5,6 +5,7 @@ Defines LinuxForHealth exceptions.
 
 """
 
+
 class MissingFhirResourceType(Exception):
     """Raised when an input FHIR message does not contain a resourceType"""
     def __init__(self, msg=None):

--- a/pyconnect/main.py
+++ b/pyconnect/main.py
@@ -4,16 +4,14 @@ main.py
 Bootstraps the Fast API application and Uvicorn processes
 """
 from fastapi import (FastAPI,
-                     HTTPException,
-                     Request)
+                     HTTPException)
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 import uvicorn
 from pyconnect.config import get_settings
 from pyconnect.routes.api import router
 from pyconnect import __version__
-from pyconnect.server_handlers import (configure_clients,
+from pyconnect.server_handlers import (configure_internal_integrations,
                                        configure_logging,
-                                       configure_nats_subscribers,
                                        http_exception_handler)
 
 settings = get_settings()
@@ -32,8 +30,7 @@ def get_app() -> FastAPI:
     app.add_middleware(HTTPSRedirectMiddleware)
     app.include_router(router)
     app.add_event_handler('startup', configure_logging)
-    app.add_event_handler('startup', configure_clients)
-    app.add_event_handler('startup', configure_nats_subscribers)
+    app.add_event_handler('startup', configure_internal_integrations)
     app.add_exception_handler(HTTPException, http_exception_handler)
     return app
 

--- a/pyconnect/nats_subscribers/persist_to_kafka.py
+++ b/pyconnect/nats_subscribers/persist_to_kafka.py
@@ -12,12 +12,12 @@ from pyconnect.clients import (get_kafka_producer,
 kafka_producer = None
 
 
-"""
-Subscribes to ACTIONS.persist NATS messages and sends each message
-payload to Kafka for storage.  Before sending to Kafka, each message is formatted
-in the LinuxForHealth message format.
-"""
 async def start_persist_subscriber():
+    """
+    Subscribes to ACTIONS.persist NATS messages and sends each message
+    payload to Kafka for storage.  Before sending to Kafka, each message is formatted
+    in the LinuxForHealth message format.
+    """
     global kafka_producer
     kafka_producer = get_kafka_producer()
     nc = await get_nats_client()
@@ -25,10 +25,10 @@ async def start_persist_subscriber():
     return sid
 
 
-"""
-Callback for ACTIONS.persist messages
-"""
 async def message_handler(msg: Msg):
+    """
+    Callback for ACTIONS.persist messages
+    """
     subject = msg.subject
     reply = msg.reply
     data = msg.data.decode()

--- a/pyconnect/routes/fhir.py
+++ b/pyconnect/routes/fhir.py
@@ -19,8 +19,7 @@ router = APIRouter()
 async def post_fhir_data(request_data: dict = Body(...)):
     """
     Receive a single FHIR data record
-
-    :param message: The incoming FHIR message
+    :param request_data: The incoming FHIR message
     :return: The resulting FHIR message
     """
     try:
@@ -41,7 +40,8 @@ def instantiate_fhir_class(data: dict):
     :return: FHIR resource class instance
     """
     resource_type = data.pop("resourceType", None)
-    if (resource_type is None): raise MissingFhirResourceType
+    if resource_type is None:
+        raise MissingFhirResourceType
 
     # Use fhir.resources methods to instantiate a FHIR resource
     model_class = get_fhir_model_class(resource_type)

--- a/pyconnect/server_handlers.py
+++ b/pyconnect/server_handlers.py
@@ -40,18 +40,14 @@ def configure_logging() -> None:
         logging.info('Logging configuration not found. Applying basic logging configuration.')
 
 
-async def configure_clients() -> None:
+async def configure_internal_integrations() -> None:
     """
-    Configures pyConnect service clients for internal and external integrations
+    Configure internal integrations to support:
+    - Kafka
+    - NATS Messaging/Jetstream
     """
     get_kafka_producer()
     await get_nats_client()
-
-
-async def configure_nats_subscribers() -> None:
-    """
-    Configures pyConnect NATS subscribers for internal and external integrations
-    """
     await create_nats_subscribers()
 
 
@@ -61,5 +57,5 @@ async def http_exception_handler(request: Request, exc: HTTPException):
     """
     return JSONResponse(
         status_code = exc.status_code,
-        content = {"detail": f"{exc.detail}"}
+        content = {'detail': f'{exc.detail}'}
     )

--- a/pyconnect/workflows/core.py
+++ b/pyconnect/workflows/core.py
@@ -9,6 +9,7 @@ import xworkflows
 from pyconnect.clients import get_nats_client
 from pydantic.json import pydantic_encoder
 
+
 class CoreWorkflowDef(xworkflows.Workflow):
     """
     Implements the base LinuxForHealth workflow definition.
@@ -34,6 +35,7 @@ class CoreWorkflowDef(xworkflows.Workflow):
 
     initial_state = 'parse'
 
+
 class CoreWorkflow(xworkflows.WorkflowEnabled):
     """
     Implements the base LinuxForHealth workflow.
@@ -43,27 +45,27 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
 
     state = CoreWorkflowDef()
 
-    """
-    Override to send the message to a NATS subscriber for validation.
-    """
     @xworkflows.transition('do_validate')
-    def validate(self): pass
+    def validate(self):
+        """
+        Override to send the message to a NATS subscriber for validation.
+        """
+        pass
 
-
-    """
-    Override to send the message to a NATS subscriber for transformation from one
-    form or protocol to another (e.g. HL7v2 to FHIR or FHIR R3 to R4).
-    """
     @xworkflows.transition('do_transform')
-    def transform(self): pass
+    def transform(self):
+        """
+        Override to send the message to a NATS subscriber for transformation from one
+        form or protocol to another (e.g. HL7v2 to FHIR or FHIR R3 to R4).
+        """
+        pass
 
-
-    """
-    Send the message to a NATS subscriber for persistence, including transformation of
-    the message to the LinuxForHealth data storage format.
-    """
     @xworkflows.transition('do_persist')
     async def persist(self):
+        """
+        Send the message to a NATS subscriber for persistence, including transformation of
+        the message to the LinuxForHealth data storage format.
+        """
         nc = await get_nats_client()
 
         # json.dumps filters out all the None values in the generated resource,
@@ -72,30 +74,34 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         await nc.publish("ACTIONS.persist", bytearray(msg_str, 'utf-8'))
         self.message = json.loads(msg_str)
 
-
-    """
-    Send the message to a NATS subscriber for transmission to an external service via HTTP.
-    """
     @xworkflows.transition('do_transmit')
-    def transmit(self): pass
+    def transmit(self):
+        """
+        Send the message to a NATS subscriber for transmission to an external service via HTTP.
+        """
         # TODO: Provide default http transmission in CoreWorkflow
+        pass
 
-
-    """
-    Send the message to a NATS subscriber for synchronization across LFH instances.
-    """
     @xworkflows.transition('do_sync')
-    def synchronize(self): pass
+    def synchronize(self):
+        """
+        Send the message to a NATS subscriber for synchronization across LFH instances.
+        """
         # TODO: Create default NATS subscriber for EVENTS.* and synchronize data to all subscribers
+        pass
 
-    """
-    Send the message to a NATS subscriber to record errors.
-    """
     @xworkflows.transition('handle_error')
     def error(self, error):
+        """
+        Send the message to a NATS subscriber to record errors.
+        """
         logging.info("CoreWorkflow: Processing error: ", error)
 
     async def run(self):
+        """
+        Executes the workflow
+        :return: the processed message
+        """
         try:
             logging.info("Running CoreWorkflow, starting state=", self.state)
             self.validate()

--- a/pyconnect/workflows/fhir.py
+++ b/pyconnect/workflows/fhir.py
@@ -6,6 +6,7 @@ Customizes the base LinuxForHealth workflow definition for FHIR resources.
 import logging
 from pyconnect.workflows.core import CoreWorkflow
 
+
 class FhirWorkflow(CoreWorkflow):
     """
     Implements a FHIR validation and storage workflow for LinuxForHealth.


### PR DESCRIPTION
This PR makes the following changes:

- the custom SSL context for NATS is removed
- all "internal" bootstrapping for NATS and Kafka is handled in `configure_internal_integrations`
- minor formatting/linting updates

I am able to startup pyConnect without issues using the process outlined in the attached PDF.
[pyConnect-SSL-Configuration.pdf](https://github.com/LinuxForHealth/pyconnect/files/6050887/pyConnect-SSL-Configuration.pdf)

@ccorley did you see issues with NATS tls connections during startup or when we are actually publishing/receiving a NATS message?