### PR TITLE
Improve Logging and Address Duplicate Logging Entries

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -15,9 +15,5 @@ root:
 loggers:
   pyconnect:
     level: INFO
-    handlers: [console]
-    propogate: no
-  uvicorn.access:
+  uvicorn:
     level: INFO
-    handlers: [console]
-    propogate: no

--- a/pyconnect/main.py
+++ b/pyconnect/main.py
@@ -4,8 +4,7 @@ main.py
 Bootstraps the Fast API application and Uvicorn processes
 """
 from fastapi import (FastAPI,
-                     HTTPException,
-                     Request)
+                     HTTPException)
 from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 import uvicorn
 from pyconnect.config import get_settings
@@ -14,7 +13,8 @@ from pyconnect import __version__
 from pyconnect.server_handlers import (configure_clients,
                                        configure_logging,
                                        configure_nats_subscribers,
-                                       http_exception_handler)
+                                       http_exception_handler,
+                                       log_configuration)
 
 settings = get_settings()
 
@@ -32,6 +32,7 @@ def get_app() -> FastAPI:
     app.add_middleware(HTTPSRedirectMiddleware)
     app.include_router(router)
     app.add_event_handler('startup', configure_logging)
+    app.add_event_handler('startup', log_configuration)
     app.add_event_handler('startup', configure_clients)
     app.add_event_handler('startup', configure_nats_subscribers)
     app.add_exception_handler(HTTPException, http_exception_handler)
@@ -44,6 +45,7 @@ if __name__ == '__main__':
     uvicorn_params = {
         'app': settings.uvicorn_app,
         'host': settings.uvicorn_host,
+        'log_config': None,
         'port': settings.uvicorn_port,
         'reload': settings.uvicorn_reload,
         'ssl_keyfile': settings.pyconnect_cert_key,

--- a/pyconnect/server_handlers.py
+++ b/pyconnect/server_handlers.py
@@ -1,6 +1,8 @@
+import logging
 import logging.config
 import os
 import sys
+import logging
 import yaml
 from yaml import YAMLError
 from fastapi import (HTTPException,
@@ -10,6 +12,9 @@ from pyconnect.config import get_settings
 from pyconnect.clients import (get_kafka_producer,
                                get_nats_client)
 from pyconnect.subscribers import create_nats_subscribers
+
+
+logger = logging.getLogger(__name__)
 
 
 def configure_logging() -> None:
@@ -31,13 +36,55 @@ def configure_logging() -> None:
             try:
                 logging_config = yaml.safe_load(f)
                 logging.config.dictConfig(logging_config)
+                logger.info(f'Loaded logging configuration from {settings.logging_config_path}')
             except YAMLError as e:
                 apply_basic_config()
-                logging.error(f'Unable to load logging configuration from file: {e}.')
-                logging.info('Applying basic logging configuration.')
+                logger.error(f'Unable to load logging configuration from file: {e}.')
+                logger.info('Applying basic logging configuration.')
     else:
         apply_basic_config()
-        logging.info('Logging configuration not found. Applying basic logging configuration.')
+        logger.info('Logging configuration not found. Applying basic logging configuration.')
+
+
+def log_configuration() -> None:
+    """
+    Logs pyConnect configuration settings.
+    "General" settings are logged at an INFO level.
+    "Internal" settings for clients/components are logged at a DEBUG level.
+    """
+    settings = get_settings()
+    header_footer_length = 50
+
+    logger.info('*' * header_footer_length)
+    logger.info('pyConnect Configuration Settings')
+    logger.info('=' * header_footer_length)
+    logger.info(f'UVICORN_APP: {settings.uvicorn_app}')
+    logger.info(f'UVICORN_HOST: {settings.uvicorn_host}')
+    logger.info(f'UVICORN_PORT: {settings.uvicorn_port}')
+    logger.info(f'UVICORN_RELOAD: {settings.uvicorn_reload}')
+    logger.info('=' * header_footer_length)
+
+    logger.info(f'CERTIFICATE_AUTHORITY_PATH: {settings.certificate_authority_path}')
+    logger.info(f'LOGGING_CONFIG_PATH: {settings.logging_config_path}')
+    logger.info('=' * header_footer_length)
+
+    logger.debug(f'KAFKA_BOOTSTRAP_SERVERS: {settings.kafka_bootstrap_servers}')
+    logger.debug(f'KAFKA_PRODUCER_ACKS: {settings.kafka_producer_acks}')
+    logger.debug('=' * header_footer_length)
+
+    logger.debug(f'NATS_SERVERS: {settings.nats_servers}')
+    logger.debug(f'NATS_ALLOW_RECONNECT: {settings.nats_allow_reconnect}')
+    logger.debug(f'NATS_MAX_RECONNECT_ATTEMPTS: {settings.nats_max_reconnect_attempts}')
+    logger.debug(f'NATS_ROOTCA_FILE: {settings.nats_rootCA_file}')
+    logger.debug(f'NATS_CERT_FILE: {settings.nats_cert_file}')
+    logger.debug(f'NATS_KEY_FILE: {settings.nats_key_file}')
+    logger.debug('=' * header_footer_length)
+
+    logger.debug(f'PYCONNECT_CERT: {settings.pyconnect_cert}')
+    logger.debug(f'PYCONNECT_CERT_KEY: {settings.pyconnect_cert_key}')
+    logger.debug('=' * header_footer_length)
+
+    logger.info('*' * header_footer_length)
 
 
 async def configure_clients() -> None:


### PR DESCRIPTION
This PR updates pyConnect's logging configuration with the following:

- Remove handler definitions from child loggers in logging.yaml to address issues with duplicate log messages.
- Remove the uvicorn default logging configuration as it also had issues with duplicate log messages.
- Add logging to server_handler.py to display configuration settings

New logging output
```shell
/Users/tdw/projects/lfh/pyconnect/venv/bin/python /Users/tdw/projects/lfh/pyConnect/pyconnect/main.py
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - Loaded logging configuration from logging.yaml
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - **************************************************
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - pyConnect Configuration Settings
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - ==================================================
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - UVICORN_APP: pyconnect.main:app
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - UVICORN_HOST: 0.0.0.0
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - UVICORN_PORT: 5000
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - UVICORN_RELOAD: True
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - ==================================================
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - CERTIFICATE_AUTHORITY_PATH: /Users/tdw/projects/lfh/pyconnect/venv/lib/python3.8/site-packages/certifi/cacert.pem
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - LOGGING_CONFIG_PATH: logging.yaml
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - ==================================================
2021-02-27 09:50:51,933 - pyconnect.server_handlers - INFO - **************************************************
2021-02-27 09:50:51,991 - uvicorn.error - INFO - Application startup complete.
```

Additional Kafka, NATS, and pyConnect configuration settings are logged at `DEBUG` level.

resolves #45 