### PR TITLE
Uvicorn Does Not Reload or Shutdown

### DIFF
--- a/pyconnect/clients.py
+++ b/pyconnect/clients.py
@@ -85,7 +85,8 @@ def get_kafka_producer() -> Optional[ConfluentAsyncKafkaProducer]:
             'bootstrap.servers': ''.join(settings.kafka_bootstrap_servers),
             'acks': settings.kafka_producer_acks
         }
-        kafka_producer = ConfluentAsyncKafkaProducer(configs=producer_config)
+        kafka_producer = ConfluentAsyncKafkaProducer(configs=producer_config,
+                                                     loop=asyncio.get_running_loop())
     return kafka_producer
 
 
@@ -105,6 +106,7 @@ async def get_nats_client() -> Optional[NatsClient]:
         nats_client = NatsClient()
         await nats_client.connect(
             servers=settings.nats_servers,
+            loop=asyncio.get_running_loop(),
             tls=ssl_ctx,
             allow_reconnect=settings.nats_allow_reconnect,
             max_reconnect_attempts=settings.nats_max_reconnect_attempts)

--- a/pyconnect/main.py
+++ b/pyconnect/main.py
@@ -11,7 +11,8 @@ import uvicorn
 from pyconnect.config import get_settings
 from pyconnect.routes.api import router
 from pyconnect import __version__
-from pyconnect.server_handlers import (configure_clients,
+from pyconnect.server_handlers import (close_internal_clients,
+                                       configure_clients,
                                        configure_logging,
                                        configure_nats_subscribers,
                                        http_exception_handler)
@@ -34,6 +35,7 @@ def get_app() -> FastAPI:
     app.add_event_handler('startup', configure_logging)
     app.add_event_handler('startup', configure_clients)
     app.add_event_handler('startup', configure_nats_subscribers)
+    app.add_event_handler('shutdown', close_internal_clients)
     app.add_exception_handler(HTTPException, http_exception_handler)
     return app
 

--- a/pyconnect/server_handlers.py
+++ b/pyconnect/server_handlers.py
@@ -55,6 +55,19 @@ async def configure_nats_subscribers() -> None:
     await create_nats_subscribers()
 
 
+def close_internal_clients() -> None:
+    """
+    Closes internal pyConnect client connections:
+    - Kafka
+    - NATS
+    """
+    kafka_producer = get_kafka_producer()
+    kafka_producer.close()
+
+    nats_client = get_nats_client()
+    nats_client.close()
+
+
 async def http_exception_handler(request: Request, exc: HTTPException):
     """
     Allows HTTPExceptions to be thrown without being parsed against a response model.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         'pyaml==20.4.0',
         'xworkflows==1.0.4',
         'fhir.resources==6.1.0',
-        'uvicorn==0.13.3',
+        'uvicorn[standard]==0.13.4',
     ],
     extras_require={
         'test': ['pytest==6.1.2'],


### PR DESCRIPTION
This PR updates pyConnect to ensure that Fast API will shutdown client connections to support Uvicorn's reload feature and a clean shutdown.

Specific changes include:
- Uvicorn is updated to 0.13.4 with "standard" options including "watchdog" for improved file monitoring for reloads
- clients (nats and kafka) are associated with `asyncio.get_running_loop` to ensure that a loop exists and is not created behind the scenes
- a Fast API shutdown hook is added to support client shutdown

closes #43 