### PR TITLE
Added async client for async route tests

### DIFF
--- a/pyconnect/exceptions.py
+++ b/pyconnect/exceptions.py
@@ -34,4 +34,3 @@ class KafkaStorageError(Exception):
     """Raised when storing data in Kafka fails"""
     def __init__(self, msg):
         super(KafkaStorageError, self).__init__(msg)
-        

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,10 @@ setuptools.setup(
         'xworkflows==1.0.4',
         'fhir.resources==6.1.0',
         'uvicorn[standard]==0.13.4',
+        'httpx==0.17.0'
     ],
     extras_require={
-        'test': ['pytest==6.1.2'],
+        'test': ['pytest==6.1.2', 'pytest-asyncio==0.14.0'],
         'dev': ['autopep8==1.5.5', 'pylint==2.6.0']
     },
     python_requires='>=3.7'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,13 +100,16 @@ def mock_async_kafka_producer() -> Callable:
             class CallbackMessage:
                 """ Message to send to producer callback"""
                 @staticmethod
-                def topic(): return topic
+                def topic():
+                    return topic
 
                 @staticmethod
-                def partition(): return 0
+                def partition():
+                    return 0
 
                 @staticmethod
-                def offset(): return 0
+                def offset():
+                    return 0
 
             on_delivery(None, CallbackMessage())
 

--- a/tests/routes/test1_data.py
+++ b/tests/routes/test1_data.py
@@ -1,5 +1,5 @@
 """
-test_data.py
+test1_data.py
 Tests /data endpoints
 """
 

--- a/tests/routes/test1_status.py
+++ b/tests/routes/test1_status.py
@@ -1,5 +1,5 @@
 """
-test_status.py
+test1_status.py
 Tests the /status API endpoints
 """
 import socket

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -3,21 +3,18 @@ test_fhir.py
 Tests the /fhir endpoint
 """
 import pytest
-import socket
 from pyconnect import clients
 
 
 @pytest.mark.asyncio
-async def test_fhir_post(async_test_client, mock_client_socket,
-                         mock_async_kafka_producer, monkeypatch):
+async def test_fhir_post(async_test_client, mock_async_kafka_producer, monkeypatch):
     """
     Tests /fhir [POST]
-    :param test_client: Fast API test client
-    :param mock_client_socket: Mock Client Socket Fixture
+    :param async_test_client: HTTPX test client fixture
+    :param mock_async_kafka_producer: Mock Kafka producer fixture
     :param monkeypatch: MonkeyPatch instance used to mock test cases
     """
     with monkeypatch.context() as m:
-        m.setattr(socket, 'socket', mock_client_socket)
         m.setattr(clients, 'ConfluentAsyncKafkaProducer', mock_async_kafka_producer)
 
         async with async_test_client as ac:

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -2,6 +2,7 @@
 test_fhir.py
 Tests the /fhir endpoint
 """
+import json
 import pytest
 from pyconnect import clients
 
@@ -29,16 +30,25 @@ async def test_fhir_post(async_test_client, mock_async_kafka_producer, monkeypat
         print(f'actual_response = {actual_response}')
         assert actual_response.status_code == 200
 
-        # actual_json = actual_response.json()
-        # assert 'id' in actual_json
-        # assert 'active' in actual_json
-        # assert 'gender' in actual_json
-        # assert 'resourceType' in actual_json
+        actual_json = actual_response.json()
+        assert 'uuid' in actual_json
+        assert 'creation_date' in actual_json
+        assert 'store_date' in actual_json
+        assert 'transmit_date' in actual_json
+        assert 'target_endpoint_url' in actual_json
+        assert 'elapsed_storage_time' in actual_json
+        assert 'elapsed_transmit_time' in actual_json
+        assert 'elapsed_total_time' in actual_json
 
-        # expected = {
-        #    "id": "001",
-        #    "active": True,
-        #    "gender": "male",
-        #    "resourceType": "Patient"
-        #}
-        #assert actual_json == expected
+        expected_data = {
+            "id": "001",
+            "active": True,
+            "gender": "male",
+            "resourceType": "Patient"
+        }
+        expected_data_str = json.dumps(expected_data)
+        assert actual_json['data'] == expected_data_str
+        assert actual_json['consuming_endpoint_url'] == '/fhir'
+        assert actual_json['data_format'] == 'PATIENT'
+        assert actual_json['status'] == 'success'
+        assert actual_json['data_record_location'] == 'PATIENT:0:0'


### PR DESCRIPTION
Changes include:
  * Added an HTTPX AsyncClient for async route testing
  * Extended /fhir route test
  * Ordered sync tests before async tests to preserve socket mocking for sync tests
