### PR TITLE
Refactored sync test names

### DIFF
--- a/tests/routes/test_1data.py
+++ b/tests/routes/test_1data.py
@@ -1,5 +1,5 @@
 """
-test1_data.py
+test_1data.py
 Tests /data endpoints
 """
 

--- a/tests/routes/test_1status.py
+++ b/tests/routes/test_1status.py
@@ -1,5 +1,5 @@
 """
-test1_status.py
+test_1status.py
 Tests the /status API endpoints
 """
 import socket


### PR DESCRIPTION
The refactored test cases weren't actually getting executed with the test1_* naming.  Changed to test_1*.