### PR TITLE
Annotating Tests Which Use Mock Sockets

### DIFF
--- a/tests/routes/test_status.py
+++ b/tests/routes/test_status.py
@@ -1,5 +1,5 @@
 """
-test_1status.py
+test_status.py
 Tests the /status API endpoints
 """
 import socket
@@ -7,7 +7,7 @@ import pytest
 from pyconnect.config import get_settings
 
 
-@pytest.mark.skip(reason="No way of currently testing this")
+@pytest.mark.asyncio
 def test_status_get(test_client, settings, mock_client_socket, monkeypatch):
     """
     Tests /status [GET]


### PR DESCRIPTION
This PR annotates tests that use our "mock socket" as async io tests to resolve issues with competing testing frameworks.
Moving forward we can either:
-mark tests which utilize our mock socket as async
-update the mock socket to reflect the "patched" signature used by the pytest asyncio

Either option will work. The latter will couple us a bit more to the pytest asyncio library, so perhaps the annotation is preferable.