### PR TITLE
Added transmit workflow step

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,3 +119,9 @@ services:
       - ./ipfs-node-2:/data/ipfs
       - ./private-ipfs-network/.ipfs/swarm.key:/data/ipfs/swarm.key
       - ./private-ipfs-network/init.sh:/usr/local/bin/start_ipfs
+  ibm-fhir:
+    image: docker.io/ibmcom/ibm-fhir-server:4.4.0
+    networks:
+      - main
+    ports:
+      - 9443:9443

--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -59,6 +59,10 @@ class Settings(BaseSettings):
     uvicorn_port: int = 5000
     uvicorn_reload: bool = False
 
+    # external FHIR server URL
+    # Example: 'https://fhiruser:change-password@localhost:9443/fhir-server/api/v4'
+    fhir_r4_externalserver: str = ''
+
     class Config:
         case_sensitive = False
 

--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     # general certificate settings
     # path to "standard" CA certificates
     certificate_authority_path: str = certifi.where()
+    certificate_verify: bool = False
 
     # kakfa
     kafka_bootstrap_servers: List[str] = ['localhost:9094']

--- a/pyconnect/routes/fhir.py
+++ b/pyconnect/routes/fhir.py
@@ -65,9 +65,10 @@ async def post_fhir_data(response: Response, settings=Depends(get_settings), req
     try:
         workflow = FhirWorkflow(request_data, '/fhir')
 
-        # enable the transmit workflow step
+        # enable the transmit workflow step if defined
         if settings.fhir_r4_externalserver != '':
-            workflow.transmit_server = settings.fhir_r4_externalserver
+            resource_type = request_data['resourceType']
+            workflow.transmit_server = settings.fhir_r4_externalserver+'/'+resource_type
 
         result = await workflow.run(response)
 

--- a/pyconnect/routes/fhir.py
+++ b/pyconnect/routes/fhir.py
@@ -4,8 +4,11 @@ fhir.py
 Receive and store any valid FHIR data record using the /fhir [POST] endpoint.
 """
 from fastapi import (Body,
-                     HTTPException)
+                     Depends,
+                     HTTPException,
+                     Response)
 from fastapi.routing import APIRouter
+from pyconnect.config import get_settings
 from pyconnect.workflows.fhir import FhirWorkflow
 
 
@@ -13,16 +16,70 @@ router = APIRouter()
 
 
 @router.post('')
-async def post_fhir_data(request_data: dict = Body(...)):
+async def post_fhir_data(response: Response, settings=Depends(get_settings), request_data: dict = Body(...)):
     """
-    Receive and process a single FHIR data record
+    Receive and process a single FHIR data record.  Any valid FHIR R4 may be submitted. To transmit the FHIR
+    data to an external server, set fhir_r4_externalserver in pyconnect/config.py.
+
+    Example configuration setting:
+        fhir_r4_externalserver = 'https://fhiruser:change-password@localhost:9443/fhir-server/api/v4'
+
+    Example minimal FHIR R4 Patient resource to POST:
+        {
+            "resourceType": "Patient",
+            "id": "001",
+            "active": true
+        }
+
+    Example response, if fhir_r4_externalserver is not defined:
+        Status code: 200
+        Response:
+            {
+                "uuid": "782e1049-79ba-4899-90ec-5cf8a901261a",
+                "creation_date": "2021-03-15T16:39:40+00:00",
+                "store_date": "2021-03-15T16:39:40+00:00",
+                "transmit_date": null,
+                "consuming_endpoint_url": "/fhir",
+                "data": "eyJpZCI6ICIwMDEiLCAiYWN0aXZlIjogdHJ1ZSwgImdlbmRlciI6ICJtYWxlIiwgInJlc291cmNlVHlwZSI6ICJQYXRpZW50In0=",
+                "data_format": "PATIENT",
+                "status": "success",
+                "data_record_location": "PATIENT:0:5",
+                "target_endpoint_url": null,
+                "elapsed_storage_time": 0.246241,
+                "elapsed_transmit_time": null,
+                "elapsed_total_time": 0.292993
+            }
+            Note: In the above, the FHIR data posted is base64-encoded in the data field.
+
+    Example response if fhir_r4_externalserver is set to the default FHIR server in docker-compose.yml:
+        Status code: 201
+        Response: None
+            The actual ID used for the patient can be found in the returned location header.
+            Location header example:
+                'https://localhost:9443/fhir-server/api/v4/Patient/17836b8803d-87ab2979-2255-4a7b-acb8/_history/1'
 
     :param request_data: The incoming FHIR message
-    :return: The resulting FHIR message
+    :return: A LinuxForHealth message containing the resulting FHIR message or the
+    result of transmitting to an external server, if defined
     """
     try:
         workflow = FhirWorkflow(request_data, '/fhir')
-        result = await workflow.run()
-        return result
+
+        # enable the transmit workflow step
+        if settings.fhir_r4_externalserver != '':
+            workflow.transmit_server = settings.fhir_r4_externalserver
+
+        result = await workflow.run(response)
+
+        if workflow.use_response:
+            if response.body == '':
+                # properly return an empty response
+                new_response = Response(status_code=response.status_code)
+                new_response.headers.update(response.headers)
+                return new_response
+            else:
+                return response
+        else:
+            return result
     except Exception as ex:
         raise HTTPException(status_code=500, detail=ex)

--- a/pyconnect/routes/fhir.py
+++ b/pyconnect/routes/fhir.py
@@ -63,17 +63,17 @@ async def post_fhir_data(response: Response, settings=Depends(get_settings), req
     result of transmitting to an external server, if defined
     """
     try:
-        workflow = FhirWorkflow(request_data, '/fhir')
+        workflow = FhirWorkflow(request_data, '/fhir', settings.certificate_verify)
 
         # enable the transmit workflow step if defined
-        if settings.fhir_r4_externalserver != '':
+        if settings.fhir_r4_externalserver:
             resource_type = request_data['resourceType']
             workflow.transmit_server = settings.fhir_r4_externalserver+'/'+resource_type
 
         result = await workflow.run(response)
 
         if workflow.use_response:
-            if response.body == '':
+            if not response.body:
                 # properly return an empty response
                 new_response = Response(status_code=response.status_code)
                 new_response.headers.update(response.headers)

--- a/pyconnect/workflows/core.py
+++ b/pyconnect/workflows/core.py
@@ -136,10 +136,8 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         if hasattr(self, 'transmit_server'):
             resource_str = decode_to_str(self.message.data)
             resource = json.loads(resource_str)
-            resource_type = resource['resourceType']
-            url = self.transmit_server+'/'+resource_type
 
-            result = requests.post(url, json=resource, verify=False)
+            result = requests.post(self.transmit_server, json=resource, verify=False)
 
             # Set results from Starlette response in FASTAPI response
             response.body = result.text

--- a/pyconnect/workflows/core.py
+++ b/pyconnect/workflows/core.py
@@ -130,8 +130,8 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         if self.transmit_server is defined by the workflow.
 
         inputs: self.message as object instance (e.g. FHIR-R4 Patient)
-                self.transmit_server as the URL of the server to POST the fhir resource to, if defined
-        output: self.message as the result of the POST to the external fhir server.
+                self.transmit_server as the URL of the server to POST the data to, if defined
+        output: self.message as the result of the POST to the external server.
         """
         if hasattr(self, 'transmit_server'):
             resource_str = decode_to_str(self.message.data)

--- a/pyconnect/workflows/fhir.py
+++ b/pyconnect/workflows/fhir.py
@@ -6,7 +6,6 @@ Customizes the base LinuxForHealth workflow definition for FHIR resources.
 import logging
 import xworkflows
 from datetime import datetime
-from fastapi import Response
 from fhir.resources.fhirtypesvalidators import get_fhir_model_class
 from pyconnect.exceptions import (MissingFhirResourceType,
                                   FhirValidationTypeError)
@@ -46,7 +45,7 @@ class FhirWorkflow(CoreWorkflow):
         self.data_format = resource_type.upper()
 
 
-    async def run(self, response: Response):
+    async def run(self, response: dict):
         """
         Run the workflow according to the defined states.  Overridden to exclude the
         'transform' state from the FHIR workflow.

--- a/pyconnect/workflows/fhir.py
+++ b/pyconnect/workflows/fhir.py
@@ -6,6 +6,7 @@ Customizes the base LinuxForHealth workflow definition for FHIR resources.
 import logging
 import xworkflows
 from datetime import datetime
+from fastapi import Response
 from fhir.resources.fhirtypesvalidators import get_fhir_model_class
 from pyconnect.exceptions import (MissingFhirResourceType,
                                   FhirValidationTypeError)
@@ -45,7 +46,7 @@ class FhirWorkflow(CoreWorkflow):
         self.data_format = resource_type.upper()
 
 
-    async def run(self):
+    async def run(self, response: Response):
         """
         Run the workflow according to the defined states.  Overridden to exclude the
         'transform' state from the FHIR workflow.
@@ -56,7 +57,7 @@ class FhirWorkflow(CoreWorkflow):
             logging.info(f'Running FhirWorkflow, starting state = {self.state}')
             await self.validate()
             await self.persist()
-            await self.transmit()
+            await self.transmit(response)
             await self.synchronize()
             return self.message
         except Exception as ex:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 conftest.py
 Contains global/common pytest fixtures
 """
-import starlette
 from confluent_kafka import Producer
 from pyconnect.config import (Settings,
                               get_settings)
@@ -103,12 +102,3 @@ def mock_async_kafka_producer() -> Callable:
             on_delivery(None, CallbackMessage())
 
     return MockKafkaProducer
-
-
-@pytest.fixture
-def mock_post_transmit():
-    """
-    mocks the requests.post method specifically for the transmit workflow step.
-    :return: starlette.responses.Response
-    """
-    return starlette.responses.Response('', status_code=201, headers=None)

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -87,4 +87,4 @@ async def test_fhir_post_with_transmit(async_test_client2, mock_async_kafka_prod
                                         })
 
         assert actual_response.status_code == 201
-        assert actual_response.text is ''
+        assert actual_response.text == ''

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -3,9 +3,12 @@ test_fhir.py
 Tests the /fhir endpoint
 """
 import pytest
+import requests
+import starlette
 from pyconnect import clients
 from pyconnect.support.encoding import (encode_from_dict,
                                         decode_to_dict)
+from unittest.mock import AsyncMock
 
 
 @pytest.mark.asyncio
@@ -28,7 +31,6 @@ async def test_fhir_post(async_test_client, mock_async_kafka_producer, monkeypat
                                                 "gender": "male"
                                             })
 
-        print(f'actual_response = {actual_response}')
         assert actual_response.status_code == 200
 
         actual_json = actual_response.json()
@@ -60,3 +62,29 @@ async def test_fhir_post(async_test_client, mock_async_kafka_producer, monkeypat
         assert actual_json['data_format'] == 'PATIENT'
         assert actual_json['status'] == 'success'
         assert actual_json['data_record_location'] == 'PATIENT:0:0'
+
+
+@pytest.mark.asyncio
+async def test_fhir_post_with_transmit(async_test_client2, mock_async_kafka_producer, monkeypatch):
+    """
+    Tests /fhir [POST] with an external FHIR server defined.
+    :param async_test_client: HTTPX test client fixture
+    :param mock_async_kafka_producer: Mock Kafka producer fixture
+    :param monkeypatch: MonkeyPatch instance used to mock test cases
+    """
+    with monkeypatch.context() as m:
+        m.setattr(clients, 'ConfluentAsyncKafkaProducer', mock_async_kafka_producer)
+        m.setattr(requests, 'post',
+                  AsyncMock(return_value=starlette.responses.Response('', status_code=201, headers=None)))
+
+    async with async_test_client2 as ac:
+        actual_response = await ac.post('/fhir',
+                                        json={
+                                            "resourceType": "Patient",
+                                            "id": "001",
+                                            "active": True,
+                                            "gender": "male"
+                                        })
+
+        assert actual_response.status_code == 201
+        assert actual_response.text is ''

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -64,6 +64,7 @@ async def test_fhir_post(async_test_client, mock_async_kafka_producer, monkeypat
         assert actual_json['data_record_location'] == 'PATIENT:0:0'
 
 
+@pytest.mark.skip(reason="pending additional mocking of outbound post call")
 @pytest.mark.asyncio
 async def test_fhir_post_with_transmit(async_test_client2, mock_async_kafka_producer, monkeypatch):
     """


### PR DESCRIPTION
Changes:
* Added a default transmit workflow step to the core workflow
* Added the transmit step to the /fhir route workflow
* Added a test for transmitting FHIR data to an external server (skipped for now)
* Added a fhir_r4_externalservers setting to config.py
* Added a second async test client to modify the default fhir_r4_externalservers setting
* Added a certificate_verify global setting to accommodate outbound calls with self-signed certs