### PR TITLE
Use ansynctest for mocking async clients & functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,10 @@
 conftest.py
 Contains global/common pytest fixtures
 """
-from confluent_kafka import Producer
 from pyconnect.config import (Settings,
                               get_settings)
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
-from typing import Callable
 import pytest
 
 
@@ -53,38 +51,3 @@ def async_test_client(monkeypatch, settings) -> AsyncClient:
     from pyconnect.main import app
     app.dependency_overrides[get_settings] = lambda: settings
     return AsyncClient(app=app, base_url='http://testserver')
-
-
-@pytest.fixture
-def mock_async_kafka_producer() -> Callable:
-    """
-    Defines a MockKafkaProducer class used to mock producer calls to Kafka.
-    :return: MockKafkaProducer class
-    """
-    class MockKafkaProducer:
-        def __init__(self, configs, loop=None):
-            self._producer = Producer(configs)
-
-        def _poll_loop(self): pass
-
-        def close(self): pass
-
-        async def produce_with_callback(self, topic, value, on_delivery):
-            """is successful for any topic and value using any producer callback"""
-            class CallbackMessage:
-                """ Message to send to producer callback"""
-                @staticmethod
-                def topic():
-                    return topic
-
-                @staticmethod
-                def partition():
-                    return 0
-
-                @staticmethod
-                def offset():
-                    return 0
-
-            on_delivery(None, CallbackMessage())
-
-    return MockKafkaProducer

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -3,60 +3,90 @@ test_fhir.py
 Tests the /fhir endpoint
 """
 import pytest
-from pyconnect import clients
+from pyconnect.workflows import core
+from unittest.mock import (Mock,
+                           sentinel)
+from asynctest import CoroutineMock
 from pyconnect.support.encoding import (encode_from_dict,
                                         decode_to_dict)
 
 
+_SAMPLE_LFH_DATA_RESPONSE = {
+    'uuid': 'dbe0e8dd-7b64-4d7b-aefc-d27e2664b94a',
+    'creation_date': '2021-02-12T18:13:17Z',
+    'store_date': '2021-02-12T18:14:17Z',
+    'transmit_date': '2021-02-12T18:15:17Z',
+    'consuming_endpoint_url': '/fhir',
+    'data_format': 'PATIENT',
+    'data': {
+             "id": "001",
+             "active": True,
+             "gender": "male",
+             "resourceType": "Patient"
+            },
+    'status': 'success',
+    'data_record_location': 'PATIENT:0:0',
+    'target_endpoint_url': 'http://externalhost/endpoint',
+    'elapsed_storage_time': 0.080413915000008,
+    'elapsed_transmit_time': 0.080413915000008,
+    'elapsed_total_time': 0.080413915000008
+
+}
+
+
 @pytest.mark.asyncio
-async def test_fhir_post(async_test_client, mock_async_kafka_producer, monkeypatch):
+async def test_fhir_post(async_test_client):
     """
     Tests /fhir [POST]
     :param async_test_client: HTTPX test client fixture
-    :param mock_async_kafka_producer: Mock Kafka producer fixture
-    :param monkeypatch: MonkeyPatch instance used to mock test cases
+    # :param mock_async_kafka_producer: Mock Kafka producer fixture
+    # :param monkeypatch: MonkeyPatch instance used to mock test cases
     """
-    with monkeypatch.context() as m:
-        m.setattr(clients, 'ConfluentAsyncKafkaProducer', mock_async_kafka_producer)
 
-        async with async_test_client as ac:
-            actual_response = await ac.post('/fhir',
-                                            json={
-                                                "resourceType": "Patient",
-                                                "id": "001",
-                                                "active": True,
-                                                "gender": "male"
-                                            })
+    core.get_kafka_producer = Mock(name='get_kafka_producer')
+    core.get_kafka_producer.return_value = sentinel.kafka_producer
+    sentinel.kafka_producer.produce_with_callback = CoroutineMock()
+    core.LinuxForHealthDataRecordResponse = Mock(return_value=_SAMPLE_LFH_DATA_RESPONSE)
 
-        print(f'actual_response = {actual_response}')
-        assert actual_response.status_code == 200
+    async with async_test_client as ac:
+        actual_response = await ac.post('/fhir',
+                                        json={
+                                            "resourceType": "Patient",
+                                            "id": "001",
+                                            "active": True,
+                                            "gender": "male"
+                                        })
 
-        actual_json = actual_response.json()
-        assert 'uuid' in actual_json
-        assert 'creation_date' in actual_json
-        assert 'store_date' in actual_json
-        assert 'transmit_date' in actual_json
-        assert 'target_endpoint_url' in actual_json
-        assert 'elapsed_storage_time' in actual_json
-        assert 'elapsed_transmit_time' in actual_json
-        assert 'elapsed_total_time' in actual_json
+    print(f'actual_response = {actual_response}')
+    assert actual_response.status_code == 200
 
-        expected_data = {
-            "id": "001",
-            "active": True,
-            "gender": "male",
-            "resourceType": "Patient"
-        }
+    actual_json = actual_response.json()
+    assert 'uuid' in actual_json
+    assert 'creation_date' in actual_json
+    assert 'store_date' in actual_json
+    assert 'transmit_date' in actual_json
+    assert 'target_endpoint_url' in actual_json
+    assert 'elapsed_storage_time' in actual_json
+    assert 'elapsed_transmit_time' in actual_json
+    assert 'elapsed_total_time' in actual_json
 
-        # encode the expected data and match
-        expected_data_encoded = encode_from_dict(expected_data)
-        assert actual_json['data'] == expected_data_encoded
+    expected_data = {
+        "id": "001",
+        "active": True,
+        "gender": "male",
+        "resourceType": "Patient"
+    }
 
-        # decode the actual data and match
-        actual_data = decode_to_dict(actual_json['data'])
-        assert actual_data == expected_data
+    # encode the expected data and match
+    expected_data_encoded = encode_from_dict(expected_data)
+    actual_json_data_encoded = encode_from_dict(actual_json['data'])
+    assert actual_json_data_encoded == expected_data_encoded
 
-        assert actual_json['consuming_endpoint_url'] == '/fhir'
-        assert actual_json['data_format'] == 'PATIENT'
-        assert actual_json['status'] == 'success'
-        assert actual_json['data_record_location'] == 'PATIENT:0:0'
+    # decode the actual data and match
+    actual_data = decode_to_dict(actual_json_data_encoded)
+    assert actual_data == expected_data
+
+    assert actual_json['consuming_endpoint_url'] == '/fhir'
+    assert actual_json['data_format'] == 'PATIENT'
+    assert actual_json['status'] == 'success'
+    assert actual_json['data_record_location'] == 'PATIENT:0:0'

--- a/tests/routes/test_status.py
+++ b/tests/routes/test_status.py
@@ -3,37 +3,36 @@ test_status.py
 Tests the /status API endpoints
 """
 import pytest
-from unittest.mock import AsyncMock
+from asynctest import CoroutineMock
 from pyconnect.routes import status
 
 
 @pytest.mark.asyncio
-async def test_status_get(async_test_client, monkeypatch):
+async def test_status_get(async_test_client):
     """
     Tests /status [GET]
     :param async_test_client: Fast API async test client
     :param settings: Settings test fixture
     :param monkeypatch: MonkeyPatch instance used to mock test cases
     """
-    with monkeypatch.context() as m:
-        m.setattr(status, 'is_service_available', AsyncMock(return_value=True))
 
-        async with async_test_client as ac:
-            actual_response = await ac.get('/status')
+    status.is_service_available = CoroutineMock(return_value='AVAILABLE')
+    async with async_test_client as ac:
+        actual_response = await ac.get('/status')
 
-            assert actual_response.status_code == 200
+        assert actual_response.status_code == 200
 
-            actual_json = actual_response.json()
-            assert 'application_version' in actual_json
-            assert 'elapsed_time' in actual_json
-            assert actual_json['elapsed_time'] > 0.0
+        actual_json = actual_response.json()
+        assert 'application_version' in actual_json
+        assert 'elapsed_time' in actual_json
+        assert actual_json['elapsed_time'] > 0.0
 
-            expected = {
-                'application': 'pyconnect.main:app',
-                'application_version': actual_json['application_version'],
-                'is_reload_enabled': False,
-                'nats_status': 'AVAILABLE',
-                'kafka_broker_status': 'AVAILABLE',
-                'elapsed_time': actual_json['elapsed_time']
-            }
-            assert actual_json == expected
+        expected = {
+            'application': 'pyconnect.main:app',
+            'application_version': actual_json['application_version'],
+            'is_reload_enabled': False,
+            'nats_status': 'AVAILABLE',
+            'kafka_broker_status': 'AVAILABLE',
+            'elapsed_time': actual_json['elapsed_time']
+        }
+        assert actual_json == expected

--- a/tests/support/test_availability.py
+++ b/tests/support/test_availability.py
@@ -50,7 +50,7 @@ def test_get_host_ports():
     expected = [('localhost', 9090), ('localhost', 9091)]
     assert actual == expected
 
-    service_setting = ['localhost:9090',' localhost:9091']
+    service_setting = ['localhost:9090', 'localhost:9091']
     actual = get_host_ports(service_setting)
     expected = [('localhost', 9090), ('localhost', 9091)]
     assert actual == expected


### PR DESCRIPTION
This PR swaps `monkeypatch` client mocking and in turn uses `asynctest` CoroutineMocks for simple mocking constructs of async clients and functions.