### PR TITLE
Adding shutdown hook back to Fast API startup

### DIFF
--- a/pyconnect/main.py
+++ b/pyconnect/main.py
@@ -10,7 +10,8 @@ import uvicorn
 from pyconnect.config import get_settings
 from pyconnect.routes.api import router
 from pyconnect import __version__
-from pyconnect.server_handlers import (configure_internal_integrations,
+from pyconnect.server_handlers import (close_internal_clients,
+                                       configure_internal_integrations,
                                        configure_logging,
                                        http_exception_handler)
 
@@ -32,6 +33,7 @@ def get_app() -> FastAPI:
     app.include_router(router)
     app.add_event_handler('startup', configure_logging)
     app.add_event_handler('startup', configure_internal_integrations)
+    app.add_event_handler('shutdown', close_internal_clients)
     app.add_exception_handler(HTTPException, http_exception_handler)
 
     return app


### PR DESCRIPTION
It looks like our shutdown hook was removed in the midst of renaming/refactoring things. This PR adds it back in. I verified that we are able to "reload" and "shutdown" from a terminal using ctrl + c

```
(venv) tdw@dixons-mbp pyconnect % PYCONNECT_CERT=./local-certs/lfh.pem \
PYCONNECT_CERT_KEY=./local-certs/lfh.key \
UVICORN_RELOAD=True \
python pyconnect/main.py
2021-03-16 14:40:22,843 - pyconnect.server_handlers - INFO - Loaded logging configuration from logging.yaml
2021-03-16 14:40:22,889 - uvicorn.error - INFO - Application startup complete.
^C2021-03-16 14:40:24,742 - uvicorn.error - INFO - Shutting down
2021-03-16 14:40:24,843 - uvicorn.error - INFO - Waiting for application shutdown.
2021-03-16 14:40:24,928 - uvicorn.error - INFO - Application shutdown complete.
2021-03-16 14:40:24,928 - uvicorn.error - INFO - Finished server process [77541]
```

resolves #65 