### PR TITLE
FHIR Route Updates

### DIFF
--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
 
     # external FHIR server URL
     # Example: 'https://fhiruser:change-password@localhost:9443/fhir-server/api/v4'
-    fhir_r4_externalserver: str = ''
+    fhir_r4_externalserver: str = None
 
     class Config:
         case_sensitive = False

--- a/pyconnect/routes/fhir.py
+++ b/pyconnect/routes/fhir.py
@@ -58,6 +58,8 @@ async def post_fhir_data(response: Response, settings=Depends(get_settings), req
             Location header example:
                 'https://localhost:9443/fhir-server/api/v4/Patient/17836b8803d-87ab2979-2255-4a7b-acb8/_history/1'
 
+    :param response: The response object which will be returned to the client
+    :param settings: pyConnect configuration settings
     :param request_data: The incoming FHIR message
     :return: A LinuxForHealth message containing the resulting FHIR message or the
     result of transmitting to an external server, if defined

--- a/pyconnect/workflows/core.py
+++ b/pyconnect/workflows/core.py
@@ -5,7 +5,7 @@ Provides the base LinuxForHealth workflow definition.
 """
 import json
 import logging
-import requests
+from httpx import AsyncClient
 import uuid
 import xworkflows
 from datetime import datetime
@@ -91,8 +91,8 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
                 data field as stingified json.
         """
         data = self.message
-        logging.debug(f'CoreWorkflow.persist: incoming message = {data}')
-        logging.debug(f'CoreWorkflow.persist: incoming message type = {type(data)}')
+        logging.debug(f'{self.__class__.__name__}: incoming message = {data}')
+        logging.debug(f'{self.__class__.__name__}: incoming message type = {type(data)}')
         data_encoded = encode_from_dict(data.dict())
 
         message = {
@@ -110,7 +110,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         await kafka_producer.produce_with_callback(self.data_format, msg_str,
                                                    on_delivery=get_kafka_result)
         storage_delta = datetime.now() - storage_start
-        logging.debug(f'CoreWorkflow.persist: stored resource location = {kafka_result}')
+        logging.debug(f'{self.__class__.__name__}.persist: stored resource location = {kafka_result}')
 
         total_time = datetime.utcnow() - self.start_time
         message['elapsed_storage_time'] = str(storage_delta.total_seconds())
@@ -119,7 +119,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         message['status'] = kafka_status
 
         lfh_message = LinuxForHealthDataRecordResponse(**message)
-        logging.debug(f'CoreWorkflow.persist: outgoing message = {lfh_message}')
+        logging.debug(f'{self.__class__.__name__}: outgoing message = {lfh_message}')
         self.message = lfh_message
 
 
@@ -137,7 +137,8 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
             resource_str = decode_to_str(self.message.data)
             resource = json.loads(resource_str)
 
-            result = requests.post(self.transmit_server, json=resource, verify=self.verify_certs)
+            async with AsyncClient(verify=self.verify_certs) as client:
+                result = await client.post(self.transmit_server, json=resource)
 
             # Set results from Starlette response in FASTAPI response
             response.body = result.text
@@ -179,12 +180,12 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         self.start_time = datetime.utcnow()
 
         try:
-            logging.info(f'Running CoreWorkflow, message={self.message}')
-            self.validate()
-            self.transform()
+            logging.info(f'Running {self.__class__.__name__}, message={self.message}')
+            await self.validate()
+            await self.transform()
             await self.persist()
-            self.transmit(response)
-            self.synchronize()
+            await self.transmit(response)
+            await self.synchronize()
             return self.message
         except Exception as ex:
             self.error(ex)

--- a/pyconnect/workflows/fhir.py
+++ b/pyconnect/workflows/fhir.py
@@ -5,7 +5,6 @@ Customizes the base LinuxForHealth workflow definition for FHIR resources.
 """
 import logging
 import xworkflows
-from datetime import datetime
 from fhir.resources.fhirtypesvalidators import get_fhir_model_class
 from pyconnect.exceptions import (MissingFhirResourceType,
                                   FhirValidationTypeError)
@@ -43,22 +42,3 @@ class FhirWorkflow(CoreWorkflow):
         logging.debug(f'FhirWorkflow.validate: validated resource = {resource}')
         self.message = resource
         self.data_format = resource_type.upper()
-
-
-    async def run(self, response: dict):
-        """
-        Run the workflow according to the defined states.  Overridden to exclude the
-        'transform' state from the FHIR workflow.
-        """
-        self.start_time = datetime.utcnow()
-
-        try:
-            logging.info(f'Running FhirWorkflow, starting state = {self.state}')
-            await self.validate()
-            await self.persist()
-            await self.transmit(response)
-            await self.synchronize()
-            return self.message
-        except Exception as ex:
-            self.error(ex)
-            raise

--- a/pyconnect/workflows/fhir.py
+++ b/pyconnect/workflows/fhir.py
@@ -16,7 +16,7 @@ class FhirWorkflow(CoreWorkflow):
     Implements a FHIR validation and storage workflow for LinuxForHealth.
     """
     @xworkflows.transition('do_validate')
-    async def validate(self):
+    def validate(self):
         """
         Overridden to validate the incoming FHIR message by instantiating a fhir.resources
         class from the input data dictionary.  Adapted from fhir.resources fhirtypesvalidators.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ def async_test_client(monkeypatch) -> AsyncClient:
     monkeypatch.setenv('PYCONNECT_CERT', './mycert.pem')
     monkeypatch.setenv('PYCONNECT_CERT_KEY', './mycert.key')
     from pyconnect.main import app
+    app.dependency_overrides[get_settings] = lambda: settings
     return AsyncClient(app=app, base_url='http://testserver')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,6 @@ def async_test_client(monkeypatch) -> AsyncClient:
     monkeypatch.setenv('PYCONNECT_CERT', './mycert.pem')
     monkeypatch.setenv('PYCONNECT_CERT_KEY', './mycert.key')
     from pyconnect.main import app
-    app.dependency_overrides[get_settings] = lambda: settings
     return AsyncClient(app=app, base_url='http://testserver')
 
 


### PR DESCRIPTION
FHIR Route Enhancements

The changes in this PR were generated after doing additional review on a test case issue, specifically mocking the FHIR endpoint when an external location is configured.

Changes include:

- Updated core workflow to use httpx rather than requests to ensure that the transmit step is “await-able” (required for async keyword)
- Updated core workflow run to use “await” where appropriate .
- Removed “run” implementation from FHIR workflow as we can use defaults in this case which include some no-op/pass through implementations
- Opted for a default "settings" where the FHIR external route is enabled

The changes related to the fhir external server test are annotated. It's a valid approach but will be cumbersome to duplicate as we add additional data routes. I think it would be beneficial if we took an alternate approach and implemented #74 (implement external server fixtures).