### PR TITLE
PyConnectJSONEncoder Implementation

### DIFF
--- a/pyconnect/support/encoding.py
+++ b/pyconnect/support/encoding.py
@@ -20,7 +20,8 @@ class PyConnectEncoder(JSONEncoder):
     """
     def default(self, o: Any) -> Any:
         """
-
+        Overridden to customize the encoding process.
+        :param o: The current object to encode
         """
         if isinstance(o, (datetime.date, datetime.datetime, datetime.time)):
             return o.isoformat()

--- a/pyconnect/support/encoding.py
+++ b/pyconnect/support/encoding.py
@@ -6,6 +6,28 @@ encoding.py
 """
 import base64
 import json
+from json import JSONEncoder
+import datetime
+from typing import Any
+import uuid
+
+
+class PyConnectEncoder(JSONEncoder):
+    """
+    Provides additional encoding support for the following types:
+    - UUID fields
+    - date, datetime, and time fields
+    """
+    def default(self, o: Any) -> Any:
+        """
+
+        """
+        if isinstance(o, (datetime.date, datetime.datetime, datetime.time)):
+            return o.isoformat()
+        elif isinstance(o, uuid.UUID):
+            return str(o)
+        else:
+            return super().default(o)
 
 
 def encode_from_dict(data: dict) -> str:
@@ -14,7 +36,7 @@ def encode_from_dict(data: dict) -> str:
     :param data: The dict for an object to encode
     :return: string representation of base64-encoded object
     """
-    data_str = json.dumps(data)
+    data_str = json.dumps(data, cls=PyConnectEncoder)
     data_bytes = bytes(data_str, 'utf-8')
     data_encoded_bytes = base64.b64encode(data_bytes)
     data_encoded_str = str(data_encoded_bytes, 'utf-8')

--- a/tests/support/test_encoding_utils.py
+++ b/tests/support/test_encoding_utils.py
@@ -8,20 +8,59 @@ from pyconnect.support.encoding import (encode_from_dict,
                                         encode_from_bytes,
                                         decode_to_str,
                                         decode_to_bytes,
-                                        decode_to_dict)
+                                        decode_to_dict,
+                                        PyConnectEncoder)
+import pytest
+import datetime
+import uuid
+import copy
 
 
-def test_encode_from_dict():
+@pytest.fixture(scope='module')
+def dictionary_data():
+    """
+    Dictionary data fixture used for encoding/decoding tests.
+    """
+    return {
+        'resourceType': 'Patient',
+        'id': '001',
+        'id01': 100,
+        'id02': 900.123,
+        'active': True,
+        'start_date': datetime.date(2021, 3, 23),
+        'start_date_time': datetime.datetime(2021, 3, 23, hour=15, minute=10, second=12),
+        'uuid': uuid.UUID('d897987e-133b-4236-996d-554c012ee8d9')
+    }
+
+
+@pytest.fixture(scope='module')
+def decoded_dictionary_data(dictionary_data):
+    """
+    Represents the "decoded" version of the dictionary data that has been encoded and then decoded.
+    date, datetime, time, and uuid objects are decoded as string representations
+    """
+    copied_dictionary = copy.deepcopy(dictionary_data)
+    copied_dictionary['start_date'] = copied_dictionary['start_date'].isoformat()
+    copied_dictionary['start_date_time'] = copied_dictionary['start_date_time'].isoformat()
+    copied_dictionary['uuid'] = str(copied_dictionary['uuid'])
+    return copied_dictionary
+
+
+@pytest.fixture(scope='module')
+def encoded_dictionary_data():
+    """
+    The encoded representation of the dictionary data fixture.
+    """
+    return '{"resourceType": "Patient", "id": "001", "id01": 100, "id02": 900.123, "active": true, "start_date": "2021-03-23", "start_date_time": "2021-03-23T15:10:12", "uuid": "d897987e-133b-4236-996d-554c012ee8d9"}'
+
+
+def test_encode_from_dict(dictionary_data):
     """
     Validates encode_from_dict with mock data.
+    :param dictionary_data: The dictionary data fixture used as the encoding input.
     """
-    actual_data = {
-        "resourceType": "Patient",
-        "id": "001",
-        "active": True
-    }
-    encoded_data = encode_from_dict(actual_data)
-    expected_data = 'eyJyZXNvdXJjZVR5cGUiOiAiUGF0aWVudCIsICJpZCI6ICIwMDEiLCAiYWN0aXZlIjogdHJ1ZX0='
+    encoded_data = encode_from_dict(dictionary_data)
+    expected_data = 'eyJyZXNvdXJjZVR5cGUiOiAiUGF0aWVudCIsICJpZCI6ICIwMDEiLCAiaWQwMSI6IDEwMCwgImlkMDIiOiA5MDAuMTIzLCAiYWN0aXZlIjogdHJ1ZSwgInN0YXJ0X2RhdGUiOiAiMjAyMS0wMy0yMyIsICJzdGFydF9kYXRlX3RpbWUiOiAiMjAyMS0wMy0yM1QxNToxMDoxMiIsICJ1dWlkIjogImQ4OTc5ODdlLTEzM2ItNDIzNi05OTZkLTU1NGMwMTJlZThkOSJ9'
     assert expected_data == encoded_data
 
 
@@ -65,15 +104,22 @@ def test_decode_to_bytes():
     assert expected_data == decoded_data
 
 
-def test_decode_to_dict():
+def test_decode_to_dict(decoded_dictionary_data):
     """
     Validates decode_to_dict with mock data.
+    :param: decoded_dictionary_data: The decoded dictionary fixture used as the "expected result"
     """
-    actual_data = 'eyJyZXNvdXJjZVR5cGUiOiAiUGF0aWVudCIsICJpZCI6ICIwMDEiLCAiYWN0aXZlIjogdHJ1ZX0='
+    actual_data = 'eyJyZXNvdXJjZVR5cGUiOiAiUGF0aWVudCIsICJpZCI6ICIwMDEiLCAiaWQwMSI6IDEwMCwgImlkMDIiOiA5MDAuMTIzLCAiYWN0aXZlIjogdHJ1ZSwgInN0YXJ0X2RhdGUiOiAiMjAyMS0wMy0yMyIsICJzdGFydF9kYXRlX3RpbWUiOiAiMjAyMS0wMy0yM1QxNToxMDoxMiIsICJ1dWlkIjogImQ4OTc5ODdlLTEzM2ItNDIzNi05OTZkLTU1NGMwMTJlZThkOSJ9'
     decoded_data = decode_to_dict(actual_data)
-    expected_data = {
-        "resourceType": "Patient",
-        "id": "001",
-        "active": True
-    }
-    assert expected_data == decoded_data
+    assert decoded_dictionary_data == decoded_data
+
+
+def test_pyconnect_encoder(dictionary_data, encoded_dictionary_data):
+    """
+    Tests the custom PyConnect encoder
+    :param dictionary_data: The fixture used as the encoding input
+    :param encoded_dictionary_data: The fixture used as the expected encoding result
+    """
+    encoder = PyConnectEncoder()
+    actual_value = encoder.encode(dictionary_data)
+    assert encoded_dictionary_data == actual_value


### PR DESCRIPTION
This PR adds a custom PyConnect JSON Encoder to the project to support serializing date, datetime, time, and uuid types. Utilizing a custom json encoder allows us to encapsulate the encoding logic in a single location, rather than requiring each "serialization point" to format fields to a specific format such as ISO 8601 for dates, etc.

This change will be required once we build out our data processing route samples, such as FHIR R4, and being to include date and uuid fields in our samples.

I have not included a comparable "decoder" in this PR. We can evaluate if a separate decoder is needed. We would need a separate decoder if our decoder needs to "restore" native date, datetime, time, or uuid types rather than their string representations.

resolves #82 