### PR TITLE
FHIR R4 Route Enhancements

### DIFF
--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
 
     # external FHIR server URL
     # Example: 'https://fhiruser:change-password@localhost:9443/fhir-server/api/v4'
-    fhir_r4_externalserver: str = 'https://fhiruser:change-password@localhost:9443/fhir-server/api/v4'
+    fhir_r4_externalserver: str = None
 
     class Config:
         case_sensitive = False

--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
 
     # external FHIR server URL
     # Example: 'https://fhiruser:change-password@localhost:9443/fhir-server/api/v4'
-    fhir_r4_externalserver: str = None
+    fhir_r4_externalserver: str = 'https://fhiruser:change-password@localhost:9443/fhir-server/api/v4'
 
     class Config:
         case_sensitive = False

--- a/pyconnect/exceptions.py
+++ b/pyconnect/exceptions.py
@@ -10,7 +10,7 @@ class MissingFhirResourceType(Exception):
 
     def __init__(self, msg=None):
         if msg is None:
-            msg = "Input FHIR resource is missing resourceType"
+            msg = 'Input FHIR resource is missing resourceType'
         super(MissingFhirResourceType, self).__init__(msg)
 
 

--- a/pyconnect/routes/fhir.py
+++ b/pyconnect/routes/fhir.py
@@ -10,38 +10,10 @@ from fastapi import (Body,
 from fastapi.routing import APIRouter
 from pyconnect.config import get_settings
 from pyconnect.workflows.fhir import FhirWorkflow
+from fhir.resources.fhirtypesvalidators import MODEL_CLASSES as FHIR_RESOURCES
 
 
 router = APIRouter()
-
-fhir_resources = {
-    'Account', 'ActivityDefinition', 'AdverseEvent', 'AllergyIntolerance', 'Appointment', 'AppointmentResponse',
-    'AuditEvent', 'Basic', 'Binary', 'BiologicallyDerivedProduct', 'BodyStructure', 'Bundle', 'CapabilityStatement',
-    'CarePlan', 'CareTeam', 'CatalogEntry', 'ChargeItem', 'ChargeItemDefinition', 'Claim', 'ClaimResponse',
-    'ClinicalImpression', 'CodeSystem', 'Communication', 'CommunicationRequest', 'CompartmentDefinition',
-    'Composition', 'ConceptMap', 'Condition', 'Consent', 'Contract', 'Coverage', 'CoverageEligibilityRequest',
-    'CoverageEligibilityResponse', 'DetectedIssue', 'Device', 'DeviceDefinition', 'DeviceMetric', 'DeviceRequest',
-    'DeviceUseStatement', 'DiagnosticReport', 'DocumentManifest', 'DocumentReference', 'EffectEvidenceSynthesis',
-    'Encounter', 'Endpoint', 'EnrollmentRequest', 'EnrollmentResponse', 'EpisodeOfCare', 'EventDefinition',
-    'Evidence', 'EvidenceVariable', 'ExampleScenario', 'ExplanationOfBenefit', 'FamilyMemberHistory',
-    'Flag', 'Goal', 'GraphDefinition', 'Group', 'GuidanceResponse', 'HealthcareService', 'ImagingStudy',
-    'Immunization', 'ImmunizationEvaluation', 'ImmunizationRecommendation', 'ImplementationGuide',
-    'InsurancePlan', 'Invoice', 'Library', 'Linkage', 'List', 'Location', 'Measure', 'MeasureReport',
-    'Media', 'Medication', 'MedicationAdministration', 'MedicationDispense', 'MedicationKnowledge', 'MedicationRequest',
-    'MedicationStatement', 'MedicinalProduct', 'MedicinalProductAuthorization', 'MedicinalProductContraindication',
-    'MedicinalProductIndication', 'MedicinalProductIngredient', 'MedicinalProductInteraction',
-    'MedicinalProductManufactured', 'MedicinalProductPackaged', 'MedicinalProductPharmaceutical',
-    'MedicinalProductUndesirableEffect', 'MessageDefinition', 'MessageHeader', 'MolecularSequence', 'NamingSystem',
-    'NutritionOrder', 'Observation', 'ObservationDefinition', 'OperationDefinition', 'OperationOutcome',
-    'Organization', 'OrganizationAffiliation', 'Parameters', 'Patient', 'PaymentNotice', 'PaymentReconciliation',
-    'Person', 'PlanDefinition', 'Practitioner', 'PractitionerRole', 'Procedure', 'Provenance', 'Questionnaire',
-    'QuestionnaireResponse', 'RelatedPerson', 'RequestGroup', 'ResearchDefinition', 'ResearchElementDefinition',
-    'ResearchStudy', 'ResearchSubject', 'RiskAssessment', 'RiskEvidenceSynthesis', 'Schedule', 'SearchParameter',
-    'ServiceRequest', 'Slot', 'Specimen', 'SpecimenDefinition', 'StructureDefinition', 'StructureMap',
-    'Subscription', 'Substance', 'SubstancePolymer', 'SubstanceProtein', 'SubstanceReferenceInformation',
-    'SubstanceSpecification', 'SubstanceSourceMaterial', 'SupplyDelivery', 'SupplyRequest', 'Task',
-    'TerminologyCapabilities', 'TestReport', 'TestScript', 'ValueSet', 'VerificationResult', 'VisionPrescription'
-}
 
 
 @router.post('/{resource_type}')
@@ -95,7 +67,7 @@ async def post_fhir_data(resource_type: str, response: Response, settings=Depend
     result of transmitting to an external server, if defined
     :raise: HTTPException if the /{resource_type} is invalid or does not align with the request's resource type
     """
-    if resource_type not in fhir_resources:
+    if resource_type not in FHIR_RESOURCES.keys():
         raise HTTPException(status_code=404, detail=f'/{resource_type} not found')
 
     if resource_type != request_data.get('resourceType'):

--- a/pyconnect/routes/fhir.py
+++ b/pyconnect/routes/fhir.py
@@ -14,9 +14,38 @@ from pyconnect.workflows.fhir import FhirWorkflow
 
 router = APIRouter()
 
+fhir_resources = {
+    'Account', 'ActivityDefinition', 'AdverseEvent', 'AllergyIntolerance', 'Appointment', 'AppointmentResponse',
+    'AuditEvent', 'Basic', 'Binary', 'BiologicallyDerivedProduct', 'BodyStructure', 'Bundle', 'CapabilityStatement',
+    'CarePlan', 'CareTeam', 'CatalogEntry', 'ChargeItem', 'ChargeItemDefinition', 'Claim', 'ClaimResponse',
+    'ClinicalImpression', 'CodeSystem', 'Communication', 'CommunicationRequest', 'CompartmentDefinition',
+    'Composition', 'ConceptMap', 'Condition', 'Consent', 'Contract', 'Coverage', 'CoverageEligibilityRequest',
+    'CoverageEligibilityResponse', 'DetectedIssue', 'Device', 'DeviceDefinition', 'DeviceMetric', 'DeviceRequest',
+    'DeviceUseStatement', 'DiagnosticReport', 'DocumentManifest', 'DocumentReference', 'EffectEvidenceSynthesis',
+    'Encounter', 'Endpoint', 'EnrollmentRequest', 'EnrollmentResponse', 'EpisodeOfCare', 'EventDefinition',
+    'Evidence', 'EvidenceVariable', 'ExampleScenario', 'ExplanationOfBenefit', 'FamilyMemberHistory',
+    'Flag', 'Goal', 'GraphDefinition', 'Group', 'GuidanceResponse', 'HealthcareService', 'ImagingStudy',
+    'Immunization', 'ImmunizationEvaluation', 'ImmunizationRecommendation', 'ImplementationGuide',
+    'InsurancePlan', 'Invoice', 'Library', 'Linkage', 'List', 'Location', 'Measure', 'MeasureReport',
+    'Media', 'Medication', 'MedicationAdministration', 'MedicationDispense', 'MedicationKnowledge', 'MedicationRequest',
+    'MedicationStatement', 'MedicinalProduct', 'MedicinalProductAuthorization', 'MedicinalProductContraindication',
+    'MedicinalProductIndication', 'MedicinalProductIngredient', 'MedicinalProductInteraction',
+    'MedicinalProductManufactured', 'MedicinalProductPackaged', 'MedicinalProductPharmaceutical',
+    'MedicinalProductUndesirableEffect', 'MessageDefinition', 'MessageHeader', 'MolecularSequence', 'NamingSystem',
+    'NutritionOrder', 'Observation', 'ObservationDefinition', 'OperationDefinition', 'OperationOutcome',
+    'Organization', 'OrganizationAffiliation', 'Parameters', 'Patient', 'PaymentNotice', 'PaymentReconciliation',
+    'Person', 'PlanDefinition', 'Practitioner', 'PractitionerRole', 'Procedure', 'Provenance', 'Questionnaire',
+    'QuestionnaireResponse', 'RelatedPerson', 'RequestGroup', 'ResearchDefinition', 'ResearchElementDefinition',
+    'ResearchStudy', 'ResearchSubject', 'RiskAssessment', 'RiskEvidenceSynthesis', 'Schedule', 'SearchParameter',
+    'ServiceRequest', 'Slot', 'Specimen', 'SpecimenDefinition', 'StructureDefinition', 'StructureMap',
+    'Subscription', 'Substance', 'SubstancePolymer', 'SubstanceProtein', 'SubstanceReferenceInformation',
+    'SubstanceSpecification', 'SubstanceSourceMaterial', 'SupplyDelivery', 'SupplyRequest', 'Task',
+    'TerminologyCapabilities', 'TestReport', 'TestScript', 'ValueSet', 'VerificationResult', 'VisionPrescription'
+}
 
-@router.post('')
-async def post_fhir_data(response: Response, settings=Depends(get_settings), request_data: dict = Body(...)):
+
+@router.post('/{resource_type}')
+async def post_fhir_data(resource_type: str, response: Response, settings=Depends(get_settings), request_data: dict = Body(...)):
     """
     Receive and process a single FHIR data record.  Any valid FHIR R4 may be submitted. To transmit the FHIR
     data to an external server, set fhir_r4_externalserver in pyconnect/config.py.
@@ -58,15 +87,23 @@ async def post_fhir_data(response: Response, settings=Depends(get_settings), req
             Location header example:
                 'https://localhost:9443/fhir-server/api/v4/Patient/17836b8803d-87ab2979-2255-4a7b-acb8/_history/1'
 
+    :param resource_type: Path parameter for the FHIR Resource type (Encounter, Patient, Practitioner, etc)
     :param response: The response object which will be returned to the client
     :param settings: pyConnect configuration settings
     :param request_data: The incoming FHIR message
     :return: A LinuxForHealth message containing the resulting FHIR message or the
     result of transmitting to an external server, if defined
+    :raise: HTTPException if the /{resource_type} is invalid or does not align with the request's resource type
     """
+    if resource_type not in fhir_resources:
+        raise HTTPException(status_code=404, detail=f'/{resource_type} not found')
+
+    if resource_type != request_data.get('resourceType'):
+        msg = f"request {request_data.get('resource_type')} does not match /{resource_type}"
+        raise HTTPException(status_code=422, detail=msg)
+
     try:
         workflow = FhirWorkflow(request_data, '/fhir', settings.certificate_verify)
-
         # enable the transmit workflow step if defined
         if settings.fhir_r4_externalserver:
             resource_type = request_data['resourceType']

--- a/pyconnect/workflows/fhir.py
+++ b/pyconnect/workflows/fhir.py
@@ -6,7 +6,7 @@ Customizes the base LinuxForHealth workflow definition for FHIR resources.
 import logging
 import xworkflows
 from fhir.resources import construct_fhir_element
-from pyconnect.exceptions import (FhirValidationTypeError,
+from pyconnect.exceptions import (FhirValidationError,
                                   MissingFhirResourceType)
 from pyconnect.workflows.core import CoreWorkflow
 
@@ -28,13 +28,13 @@ class FhirWorkflow(CoreWorkflow):
         resource_type = self.message.get('resourceType')
         logging.debug(f'FhirWorkflow.validate: resource type = {resource_type}')
         if resource_type is None:
-            raise MissingFhirResourceType
+            raise MissingFhirResourceType()
 
         try:
             self.message = construct_fhir_element(resource_type, self.message)
             self.data_format = resource_type.upper()
         except LookupError as le:
             logging.exception(le)
-            raise FhirValidationTypeError
+            raise FhirValidationError(str(le))
 
         logging.debug(f'FhirWorkflow.validate: validated resource = {resource_type}')

--- a/pyconnect/workflows/fhir.py
+++ b/pyconnect/workflows/fhir.py
@@ -5,9 +5,9 @@ Customizes the base LinuxForHealth workflow definition for FHIR resources.
 """
 import logging
 import xworkflows
-from fhir.resources.fhirtypesvalidators import get_fhir_model_class
-from pyconnect.exceptions import (MissingFhirResourceType,
-                                  FhirValidationTypeError)
+from fhir.resources import construct_fhir_element
+from pyconnect.exceptions import (FhirValidationTypeError,
+                                  MissingFhirResourceType)
 from pyconnect.workflows.core import CoreWorkflow
 
 
@@ -25,20 +25,16 @@ class FhirWorkflow(CoreWorkflow):
         output: self.message as an instantiated and validated fhir.resources resource class.
         raises: MissingFhirResourceType, FhirValidationTypeError
         """
-        message = self.message
-        logging.debug(f'FhirWorkflow.validate: incoming message = {message}')
-
-        resource_type = message.pop('resourceType', None)
+        resource_type = self.message.get('resourceType')
         logging.debug(f'FhirWorkflow.validate: resource type = {resource_type}')
         if resource_type is None:
             raise MissingFhirResourceType
 
-        model_class = get_fhir_model_class(resource_type)
-        resource = model_class.parse_obj(message)
+        try:
+            self.message = construct_fhir_element(resource_type, self.message)
+            self.data_format = resource_type.upper()
+        except LookupError as le:
+            logging.exception(le)
+            raise FhirValidationTypeError
 
-        if not isinstance(resource, model_class):
-            raise FhirValidationTypeError(model_class, type(resource))
-
-        logging.debug(f'FhirWorkflow.validate: validated resource = {resource}')
-        self.message = resource
-        self.data_format = resource_type.upper()
+        logging.debug(f'FhirWorkflow.validate: validated resource = {resource_type}')

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -4,19 +4,176 @@ Tests the /fhir endpoint
 """
 import pytest
 from pyconnect import clients
-from pyconnect.support.encoding import (encode_from_dict,
-                                        decode_to_dict)
 from pyconnect.config import get_settings
 from pyconnect.workflows.fhir import FhirWorkflow
 from starlette.responses import Response
 import asyncio
 
 
+@pytest.fixture
+def encounter_fixture():
+    return {
+            'resourceType': 'Encounter',
+            'id': 'emerg',
+            'text': {
+                'status': 'generated',
+                'div': '\u003cdiv xmlns\u003d\'http://www.w3.org/1999/xhtml\'\u003eEmergency visit that escalated into inpatient patient @example\u003c/div\u003e'
+            },
+            'status': 'in-progress',
+            'statusHistory': [
+                {
+                    'status': 'arrived',
+                    'period': {
+                        'start': '2017-02-01T07:15:00+10:00',
+                        'end': '2017-02-01T07:35:00+10:00'
+                    }
+                },
+                {
+                    'status': 'triaged',
+                    'period': {
+                        'start': '2017-02-01T07:35:00+10:00',
+                        'end': '2017-02-01T08:45:00+10:00'
+                    }
+                },
+                {
+                    'status': 'in-progress',
+                    'period': {
+                        'start': '2017-02-01T08:45:00+10:00',
+                        'end': '2017-02-01T12:15:00+10:00'
+                    }
+                },
+                {
+                    'status': 'onleave',
+                    'period': {
+                        'start': '2017-02-01T12:15:00+10:00',
+                        'end': '2017-02-01T12:45:00+10:00'
+                    }
+                },
+                {
+                    'status': 'in-progress',
+                    'period': {
+                        'start': '2017-02-01T12:45:00+10:00'
+                    }
+                }
+            ],
+            'class': {
+                'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+                'code': 'IMP',
+                'display': 'inpatient encounter'
+            },
+            'classHistory': [
+                {
+                    'class': {
+                        'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+                        'code': 'EMER',
+                        'display': 'emergency'
+                    },
+                    'period': {
+                        'start': '2017-02-01T07:15:00+10:00',
+                        'end': '2017-02-01T09:27:00+10:00'
+                    }
+                },
+                {
+                    'class': {
+                        'system': 'http://terminology.hl7.org/CodeSystem/v3-ActCode',
+                        'code': 'IMP',
+                        'display': 'inpatient encounter'
+                    },
+                    'period': {
+                        'start': '2017-02-01T09:27:00+10:00'
+                    }
+                }
+            ],
+            'subject': {
+                'reference': 'Patient/example'
+            },
+            'period': {
+                'start': '2017-02-01T07:15:00+10:00'
+            },
+            'hospitalization': {
+                'admitSource': {
+                    'coding': [
+                        {
+                            'system': 'http://terminology.hl7.org/CodeSystem/admit-source',
+                            'code': 'emd',
+                            'display': 'From accident/emergency department'
+                        }
+                    ]
+                }
+            },
+            'location': [
+                {
+                    'location': {
+                        'display': 'Emergency Waiting Room'
+                    },
+                    'status': 'active',
+                    'period': {
+                        'start': '2017-02-01T07:15:00+10:00',
+                        'end': '2017-02-01T08:45:00+10:00'
+                    }
+                },
+                {
+                    'location': {
+                        'display': 'Emergency'
+                    },
+                    'status': 'active',
+                    'period': {
+                        'start': '2017-02-01T08:45:00+10:00',
+                        'end': '2017-02-01T09:27:00+10:00'
+                    }
+                },
+                {
+                    'location': {
+                        'display': 'Ward 1, Room 42, Bed 1'
+                    },
+                    'status': 'active',
+                    'period': {
+                        'start': '2017-02-01T09:27:00+10:00',
+                        'end': '2017-02-01T12:15:00+10:00'
+                    }
+                },
+                {
+                    'location': {
+                        'display': 'Ward 1, Room 42, Bed 1'
+                    },
+                    'status': 'reserved',
+                    'period': {
+                        'start': '2017-02-01T12:15:00+10:00',
+                        'end': '2017-02-01T12:45:00+10:00'
+                    }
+                },
+                {
+                    'location': {
+                        'display': 'Ward 1, Room 42, Bed 1'
+                    },
+                    'status': 'active',
+                    'period': {
+                        'start': '2017-02-01T12:45:00+10:00'
+                    }
+                }
+            ],
+            'meta': {
+                'tag': [
+                    {
+                        'system': 'http://terminology.hl7.org/CodeSystem/v3-ActReason',
+                        'code': 'HTEST',
+                        'display': 'test health data'
+                    }
+                ]
+            }
+    }
+
+
 @pytest.mark.asyncio
-async def test_fhir_post(async_test_client, mock_async_kafka_producer, monkeypatch, settings):
+async def test_fhir_post(async_test_client,
+                         encounter_fixture,
+                         mock_async_kafka_producer,
+                         monkeypatch,
+                         settings):
     """
     Tests /fhir [POST] where data is not transmitted to an external server
     :param async_test_client: HTTPX test client fixture
+    :param encounter_fixture: FHIR R4 Encounter Resource fixture
     :param mock_async_kafka_producer: Mock Kafka producer fixture
     :param monkeypatch: MonkeyPatch instance used to mock test cases
     :param settings: pyConnect configuration settings fixture
@@ -29,13 +186,7 @@ async def test_fhir_post(async_test_client, mock_async_kafka_producer, monkeypat
             settings.fhir_r4_externalserver = None
             ac._transport.app.dependency_overrides[get_settings] = lambda: settings
 
-            actual_response = await ac.post('/fhir',
-                                            json={
-                                                "resourceType": "Patient",
-                                                "id": "001",
-                                                "active": True,
-                                                "gender": "male"
-                                            })
+            actual_response = await ac.post('/fhir/Encounter', json=encounter_fixture)
 
         assert actual_response.status_code == 200
 
@@ -49,36 +200,27 @@ async def test_fhir_post(async_test_client, mock_async_kafka_producer, monkeypat
         assert 'elapsed_transmit_time' in actual_json
         assert 'elapsed_total_time' in actual_json
 
-        expected_data = {
-            "id": "001",
-            "active": True,
-            "gender": "male",
-            "resourceType": "Patient"
-        }
-
-        # encode the expected data and match
-        expected_data_encoded = encode_from_dict(expected_data)
-        assert actual_json['data'] == expected_data_encoded
-
-        # decode the actual data and match
-        actual_data = decode_to_dict(actual_json['data'])
-        assert actual_data == expected_data
-
         assert actual_json['consuming_endpoint_url'] == '/fhir'
-        assert actual_json['data_format'] == 'PATIENT'
+        assert actual_json['data_format'] == 'ENCOUNTER'
         assert actual_json['status'] == 'success'
-        assert actual_json['data_record_location'] == 'PATIENT:0:0'
+        assert actual_json['data_record_location'] == 'ENCOUNTER:0:0'
 
 
 @pytest.mark.asyncio
-async def test_fhir_post_with_transmit(async_test_client, mock_async_kafka_producer, monkeypatch, settings):
+async def test_fhir_post_with_transmit(async_test_client,
+                                       encounter_fixture,
+                                       mock_async_kafka_producer,
+                                       monkeypatch,
+                                       settings):
     """
     Tests /fhir [POST] with an external FHIR server defined.
     :param async_test_client: HTTPX test client fixture
+    :param encounter_fixture: FHIR R4 Encounter Resource fixture
     :param mock_async_kafka_producer: Mock Kafka producer fixture
     :param monkeypatch: MonkeyPatch instance used to mock test cases
     :param settings: pyConnect configuration settings
     """
+
     async def mock_workflow_transmit(self, response: Response):
         """
         A mock workflow transmission method used to set a response returned to a client
@@ -94,14 +236,41 @@ async def test_fhir_post_with_transmit(async_test_client, mock_async_kafka_produ
 
         async with async_test_client as ac:
             ac._transport.app.dependency_overrides[get_settings] = lambda: settings
-            actual_response = await ac.post('/fhir',
-                                            json={
-                                                "resourceType": "Patient",
-                                                "id": "001",
-                                                "active": True,
-                                                "gender": "male"
-                                            })
+            actual_response = await ac.post('/fhir/Encounter', json=encounter_fixture)
 
             assert actual_response.status_code == 201
             assert actual_response.text == ''
             assert 'location' in actual_response.headers
+
+
+@pytest.mark.asyncio
+async def test_fhir_post_endpoints(async_test_client,
+                                   encounter_fixture,
+                                   mock_async_kafka_producer,
+                                   monkeypatch,
+                                   settings):
+    """
+    Tests /fhir [POST] endpoints to ensure that 404 and 422 status codes are returned when appropriate
+    :param async_test_client: HTTPX test client fixture
+    :param encounter_fixture: FHIR R4 Encounter Resource fixture
+    :param mock_async_kafka_producer: Mock Kafka producer fixture
+    :param monkeypatch: MonkeyPatch instance used to mock test cases
+    :param settings: pyConnect configuration settings fixture
+    """
+    with monkeypatch.context() as m:
+        m.setattr(clients, 'ConfluentAsyncKafkaProducer', mock_async_kafka_producer)
+
+        async with async_test_client as ac:
+            # remove external server setting
+            settings.fhir_r4_externalserver = None
+            ac._transport.app.dependency_overrides[get_settings] = lambda: settings
+
+            actual_response = await ac.post('/fhir/Encounter', json=encounter_fixture)
+            assert actual_response.status_code == 200
+
+            actual_response = await ac.post('/fhir/encounter', json=encounter_fixture)
+            assert actual_response.status_code == 404
+
+            encounter_fixture['resourceType'] = 'Patient'
+            actual_response = await ac.post('/fhir/Encounter', json=encounter_fixture)
+            assert actual_response.status_code == 422


### PR DESCRIPTION
This PR updates the FHIR R4 route to support the following:

- resource specific endpoints as found in the FHIR specification. LFH clients may now access /fhir/Patient, /fhir/Practitioner, etc
- resource validation to ensure that /fhir/{resource_type} is a valid resource and it aligns with the request payload.
- streamlined validation step and fhir.resources integration
- a new encounter fixture for test cases that provides a good sampling of data types including datetime fields
- new tests cases for  the fhir endpoints

I tested locally to ensure that the LFH response and integrated FHIR server responses are 👍 

closes #68 

LFH Response
```
{
  "uuid": "e304258f-f91d-4513-a296-062c3be20eca",
  "creation_date": "2021-03-23T19:12:26+00:00",
  "store_date": "2021-03-23T19:12:26+00:00",
  "transmit_date": null,
  "consuming_endpoint_url": "/fhir",
  "data": "eyJpZCI6ICJleGFtcGxlIiwgInRleHQiOiB7ImRpdiI6ICI8ZGl2IHhtbG5zPVwiaHR0cDovL3d3dy53My5vcmcvMTk5OS94aHRtbFwiPkVuY291bnRlciB3aXRoIHBhdGllbnQgQGV4YW1wbGU8L2Rpdj4iLCAic3RhdHVzIjogImdlbmVyYXRlZCJ9LCAiY2xhc3MiOiB7ImNvZGUiOiAiSU1QIiwgImRpc3BsYXkiOiAiaW5wYXRpZW50IGVuY291bnRlciIsICJzeXN0ZW0iOiAiaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS92My1BY3RDb2RlIn0sICJzdGF0dXMiOiAiaW4tcHJvZ3Jlc3MiLCAic3ViamVjdCI6IHsicmVmZXJlbmNlIjogIlBhdGllbnQvZXhhbXBsZSJ9LCAicmVzb3VyY2VUeXBlIjogIkVuY291bnRlciJ9",
  "data_format": "ENCOUNTER",
  "status": "success",
  "data_record_location": "ENCOUNTER:0:0",
  "target_endpoint_url": null,
  "elapsed_storage_time": 1.438096,
  "elapsed_transmit_time": null,
  "elapsed_total_time": 1.535659
} 
```

Integrated FHIR Server Response (Headers)
```
content-language: en-US 
 content-length: 0 
 date: Tue,23 Mar 2021 19:14:01 GMT,Tue,23 Mar 2021 19:14:04 GMT 
 etag: W/"1" 
 last-modified: Tue,23 Mar 2021 19:14:04 GMT 
 location: https://localhost:9443/fhir-server/api/v4/Encounter/17860822144-af53a106-f36f-4f74-bb56-3eed5f6e0deb/_history/1 
 server: uvicorn 
 ```