### PR TITLE
Remove asynctest Dependency

### DIFF
--- a/pyconnect/clients.py
+++ b/pyconnect/clients.py
@@ -192,7 +192,10 @@ class ConfluentAsyncKafkaConsumer:
             self.consumer.close()
 
 
-def get_kafka_consumer(topic_name, partition, offset=None, consumer_group_id=None) -> ConfluentAsyncKafkaConsumer:
+def get_kafka_consumer(topic_name: str,
+                       partition: int,
+                       offset: int = None,
+                       consumer_group_id: str = None) -> ConfluentAsyncKafkaConsumer:
     """
     Main method that allows for instantiation of an async KafkaConsumer client. Accepts optional offset(long)
     value and optional consumer_group_id(string) values. If an offset is not provided, the offset would begin
@@ -200,10 +203,10 @@ def get_kafka_consumer(topic_name, partition, offset=None, consumer_group_id=Non
 
     User is expected to call the get_message_from_kafka_cb() with a callback_method after calling this method.
 
-    :param topic_name(string): The topic name for which we would be looking up a message for.
-    :param partition(int): The partition id on which we want to look for a topic_name
-    :param Optional[offset(long)]: An optional parameter to lookup a single message that exists at a specified offset
-    :param Optional[consumer_group_id(string)]: An optional parameter to specify a consumer_group_id
+    :param topic_name: The topic name for which we would be looking up a message for.
+    :param partition: The partition id on which we want to look for a topic_name
+    :param offset: An optional parameter to lookup a single message that exists at a specified offset
+    :param consumer_group_id: An optional parameter to specify a consumer_group_id
 
     :returns: a new instance of the ConfluentAsyncKafkaConsumer
     """

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setuptools.setup(
     url='https://linuxforhealth.github.io/docs',
     classifiers=[
         'Development Status :: 4 - Beta',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Intended Audience :: Healthcare Industry'
@@ -41,7 +40,7 @@ setuptools.setup(
         'httpx==0.17.0'
     ],
     extras_require={
-        'test': ['pytest==6.1.2', 'pytest-asyncio==0.14.0', 'asynctest==0.13.0'],
+        'test': ['pytest==6.1.2', 'pytest-asyncio==0.14.0'],
         'dev': ['autopep8==1.5.5', 'pylint==2.6.0']
     },
     python_requires='>=3.8'

--- a/tests/routes/test_data.py
+++ b/tests/routes/test_data.py
@@ -3,110 +3,72 @@ test_data.py
 Tests /data endpoints
 """
 import pytest
-from confluent_kafka import KafkaException
-from pyconnect.routes import data
-from unittest.mock import (Mock,
-                           sentinel)
-from asynctest import CoroutineMock
-from pyconnect.exceptions import KafkaMessageNotFoundError
 
-_EXAMPLE_DATA_RECORD = {
-    'uuid': 'dbe0e8dd-7b64-4d7b-aefc-d27e2664b94a',
-    'creation_date': '2021-02-12T18:13:17Z',
-    'store_date': '2021-02-12T18:14:17Z',
-    'transmit_date': '2021-02-12T18:15:17Z',
-    'consuming_endpoint_url': 'https://localhost:8080/endpoint',
-    'data_format': 'EXAMPLE',
-    'data': 'SGVsbG8gV29ybGQhIEl0J3MgbWUu',
-    'status': 'success',
-    'data_record_location': 'EXAMPLE:100:4561',
-    'target_endpoint_url': 'http://externalhost/endpoint',
-    'elapsed_storage_time': 0.080413915000008,
-    'elapsed_transmit_time': 0.080413915000008,
-    'elapsed_total_time': 0.080413915000008
-}
+from pyconnect.exceptions import KafkaMessageNotFoundError
+from pyconnect.routes import data
+from unittest.mock import Mock
+
+
+@pytest.fixture
+def endpoint_parameters():
+    return {
+        'dataformat': 'EXAMPLE',
+        'partition': 100,
+        'offset': 4561
+    }
 
 
 @pytest.mark.asyncio
-async def test_get_data_record(async_test_client):
+async def test_get_data_ok(mock_async_kafka_consumer, async_test_client, endpoint_parameters, monkeypatch):
     """
-    Tests /data?dataFormat=x&partition=0&offset=0
-    :param test_client: Fast API test client
+    Tests /data where a 200 status code is returned
+    :param mock_async_kafka_consumer: The mock kafka consumer
+    :param async_test_client: The httpx async test client used to submit requests
+    :param endpoint_parameters: The endpoint parameters fixture
+    :param monkeypatch: pyTest monkeypatch fixture
     """
+    with monkeypatch.context() as m:
+        m.setattr(data, 'get_kafka_consumer', Mock(return_value=mock_async_kafka_consumer))
+        async with async_test_client as atc:
+            actual_response = await atc.get('/data', params=endpoint_parameters)
+            assert actual_response.status_code == 200
+            actual_json = actual_response.json()
+            assert actual_json['data_record_location'] == 'EXAMPLE:100:4561'
 
-    # Happy path with a 200 response from Mocked KafkaConsumer
-    data.get_kafka_consumer = Mock(name='get_kafka_consumer')
-    data.get_kafka_consumer.return_value = sentinel.kafka_consumer
-    sentinel.kafka_consumer.get_message_from_kafka_cb = CoroutineMock(return_value=_EXAMPLE_DATA_RECORD)
 
-    async with async_test_client as atc:
-        actual_response = await atc.get('/data',
-                                        params={
-                                           'dataformat': 'EXAMPLE',
-                                           'partition': 100,
-                                           'offset': 4561
-                                        })
+@pytest.mark.asyncio
+async def test_get_data_bad_request(mock_async_kafka_consumer, async_test_client, endpoint_parameters, monkeypatch):
+    """
+    Tests /data where a 400 status code is returned
+    :param mock_async_kafka_consumer: The mock kafka consumer
+    :param async_test_client: The httpx async test client used to submit requests
+    :param endpoint_parameters: The endpoint parameters fixture
+    :param monkeypatch: pyTest monkeypatch fixture
+    """
+    mock_async_kafka_consumer.get_message_from_kafka_cb.side_effect = ValueError('Test bad request')
+    with monkeypatch.context() as m:
+        m.setattr(data, 'get_kafka_consumer', Mock(return_value=mock_async_kafka_consumer))
+        async with async_test_client as atc:
+            actual_response = await atc.get('/data', params=endpoint_parameters)
+            assert actual_response.status_code == 400
+            actual_json = actual_response.json()
+            assert actual_json['detail'] == 'Test bad request'
 
-    assert actual_response.status_code == 200
-    actual_json = actual_response.json()
-    assert actual_json['data_record_location'] == 'EXAMPLE:100:4561'
 
-    #
-    # Mock raising a ValueError and assert handling with a 400 BAD REQUEST response
-    sentinel.kafka_consumer.get_message_from_kafka_cb = CoroutineMock(side_effect=ValueError('Test bad response'))
-    async with async_test_client as atc:
-        actual_response = await atc.get('/data',
-                                        params={
-                                           'dataformat': 'some_topic',
-                                           'partition': 0,
-                                           'offset': 123
-                                        })
-
-    assert actual_response.status_code == 400
-
-    #
-    # Mock raising a ValueError and assert handling with a 400 BAD REQUEST response
-    sentinel.kafka_consumer.get_message_from_kafka_cb = CoroutineMock(side_effect=ValueError('Test bad response'))
-    async with async_test_client as atc:
-        actual_response = await atc.get('/data',
-                                        params={
-                                           'dataformat': 'some_topic',
-                                           'partition': 0,
-                                           'offset': 123
-                                        })
-
-    assert actual_response.status_code == 400
-    actual_json = actual_response.json()
-    assert actual_json['detail'] == 'Test bad response'
-
-    #
-    # Mock raising a KafkaMessageNotFoundError and assert handling with a 404 NOT_FOUND response
-    sentinel.kafka_consumer.get_message_from_kafka_cb = \
-        CoroutineMock(side_effect=KafkaMessageNotFoundError('Data record not found'))
-    async with async_test_client as atc:
-        actual_response = await atc.get('/data',
-                                        params={
-                                           'dataformat': 'some_topic',
-                                           'partition': 1,
-                                           'offset': 999
-                                        })
-
-    assert actual_response.status_code == 404
-    actual_json = actual_response.json()
-    assert actual_json['detail'] == 'Data record not found'
-
-    #
-    # Mock raising a KafkaException and assert handling with a 500 ISE response
-    sentinel.kafka_consumer.get_message_from_kafka_cb = \
-        CoroutineMock(side_effect=KafkaException('KafkaConsumer exception'))
-    async with async_test_client as atc:
-        actual_response = await atc.get('/data',
-                                        params={
-                                           'dataformat': 'some_topic',
-                                           'partition': 11,
-                                           'offset': 2134
-                                        })
-
-    assert actual_response.status_code == 500
-    actual_json = actual_response.json()
-    assert actual_json['detail'] == 'KafkaConsumer exception'
+@pytest.mark.asyncio
+async def test_get_data_not_found(mock_async_kafka_consumer, async_test_client, endpoint_parameters, monkeypatch):
+    """
+    Tests /data where a 404 status code is returned
+    :param mock_async_kafka_consumer: The mock kafka consumer
+    :param async_test_client: The httpx async test client used to submit requests
+    :param endpoint_parameters: The endpoint parameters fixture
+    :param monkeypatch: pyTest monkeypatch fixture
+    """
+    mock_async_kafka_consumer.get_message_from_kafka_cb.side_effect = KafkaMessageNotFoundError('Data record not found')
+    with monkeypatch.context() as m:
+        m.setattr(data, 'get_kafka_consumer', Mock(return_value=mock_async_kafka_consumer))
+        async with async_test_client as atc:
+            actual_response = await atc.get('/data', params=endpoint_parameters)
+            assert actual_response.status_code == 404
+            actual_json = actual_response.json()
+            assert actual_json['detail'] == 'Data record not found'


### PR DESCRIPTION
This PR removes the asynctest dependency as it is no longer maintained. Changes include:

- updates to the /data endpoint/route test module where asynctest was used
- updated the KafkaConsumer docstring to address linting issues
- defined a mock kafka consumer fixture in conftest.py

resolves #76 