### PR TITLE
Fix offset OOB handling to throw an error

### DIFF
--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     kafka_consumer_default_enable_auto_commit: bool = False
     kafka_consumer_default_enable_auto_offset_store: bool = False
     kafka_consumer_default_poll_timeout_secs: float = 1.0
+    kafka_consumer_default_auto_offset_reset: str = 'error'
 
     # nats
     nats_servers: List[str] = ['tls://localhost:4222']


### PR DESCRIPTION
Referenced issue: https://github.com/LinuxForHealth/pyconnect/issues/87

While creating a `KafkaConsumer` the config `auto.offset.reset` defaults to `earliest` offset by default when an `OFFSET_OUT_OF_BOUND` error occurs for an offset not present in a partition.
This automatically forces the fetching of the earliest offset (offset 0 during our testing) on the partition without throwing an error.

The fix through the linked PR forces the consumer to return an error (which we manually catch as a `KafkaError` object instance). This manual error catch is propagated to the uvicorn Controller as a `404 NOT_FOUND` as required by design.

There is one limiting use-case which will not throw a 404 even if a message is not available at the specified offset with the partition:
- When `n` offsets are committed to the partition by a producer; the query for the `n+1`th offset (which is not available in reality) leads to a timeout (throwing a `500 ISE` instead of the expected `404`) when the consumer `poll`s. This is inherently tied to Kafka's design to wait for a message to become available at the next committed offset until the `poll_timeout_secs` config has elapsed. This design within Kafka allows for messages to be received by the consumer ASA they become available on the partition (think streaming throughput).
- Although, all `n+2` queries will lead to a `404 BAD_REQUEST` as per API design on the `/data` route