### PR TITLE
Supporting librdkafka witin alpine container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
-FROM python:3.8-alpine
+FROM python:3.9-alpine
+
+ENV LIBRDKAFKA_VERSION v1.6.1
+
+RUN apk update && \
+    apk add --no-cache --virtual .dev-packages build-base curl bash
+
+# installing librdkafka from source as alpine package repositories may lag behind python confluent kafka requirements
+# librdkafka installation procedure is attributed to https://github.com/confluentinc/confluent-kafka-python
+RUN \
+     echo Installing librdkafka && \
+     mkdir -p /usr/src/librdkafka && \
+     cd /usr/src/librdkafka && \
+     curl -LfsS https://github.com/edenhill/librdkafka/archive/${LIBRDKAFKA_VERSION}.tar.gz | \
+         tar xvzf - --strip-components=1 && \
+     ./configure --prefix=/usr --disable-lz4-ext && \
+     make -j && \
+     make install && \
+     cd / && \
+     rm -rf /usr/src/librdkafka
 
 RUN addgroup -S lfh && adduser -S lfh -G lfh -h /home/lfh
 
@@ -11,5 +30,10 @@ COPY --chown=lfh:lfh ./setup.py setup.py
 COPY --chown=lfh:lfh ./README.md README.md
 COPY --chown=lfh:lfh ./logging.yaml logging.yaml
 RUN pip install --user -e .
+
+USER root
+RUN apk del .dev-packages
+
+USER lfh
 
 CMD ["python", "/home/lfh/pyconnect/main.py"]


### PR DESCRIPTION
This PR updates our Dockerfile to support the installation of the python confluent kafka client and it's native dependency. I opted to install the native dependency from source and since the version we need is not in a "stable"/main alpine repo yet. We could have configured a pull from the "edge" repo, but we would have to go back and remove that once the dependency was migrated to the stable/main repository.

Resolves #91 