### PR TITLE
Deferred application initialization

### DIFF
--- a/pyconnect/asgi.py
+++ b/pyconnect/asgi.py
@@ -1,0 +1,3 @@
+from pyconnect.main import get_app
+
+app = get_app()

--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -56,7 +56,7 @@ class Settings(BaseSettings):
     logging_config_path: str = 'logging.yaml'
 
     # uvicorn settings
-    uvicorn_app: str = 'pyconnect.main:app'
+    uvicorn_app: str = 'pyconnect.asgi:app'
     uvicorn_host: str = '0.0.0.0'
     uvicorn_port: int = 5000
     uvicorn_reload: bool = False

--- a/pyconnect/main.py
+++ b/pyconnect/main.py
@@ -16,9 +16,6 @@ from pyconnect.server_handlers import (close_internal_clients,
                                        http_exception_handler)
 
 
-settings = get_settings()
-
-
 def get_app() -> FastAPI:
     """
     Creates the Fast API application instance
@@ -39,9 +36,9 @@ def get_app() -> FastAPI:
     return app
 
 
-app = get_app()
-
 if __name__ == '__main__':
+    settings = get_settings()
+
     uvicorn_params = {
         'app': settings.uvicorn_app,
         'host': settings.uvicorn_host,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from httpx import AsyncClient
 from typing import Callable
 import pytest
 from unittest.mock import AsyncMock
+from pyconnect.main import get_app
 
 
 @pytest.fixture
@@ -22,7 +23,7 @@ def settings() -> Settings:
         'kafka_bootstrap_servers': ['localhost:8080'],
         'nats_servers': ['tls://localhost:8080'],
         'uvicorn_reload': False,
-        'uvicorn_app': 'pyconnect.main:app',
+        'uvicorn_app': 'pyconnect.asgi:app',
         'pyconnect_cert_key': './mycert.key',
         'pyconnect_cert': './mycert.pem',
         'fhir_r4_externalserver': 'https://fhiruser:change-password@localhost:9443/fhir-server/api/v4'
@@ -59,8 +60,7 @@ def test_client(monkeypatch) -> TestClient:
     """
     monkeypatch.setenv('PYCONNECT_CERT', './mycert.pem')
     monkeypatch.setenv('PYCONNECT_CERT_KEY', './mycert.key')
-    from pyconnect.main import app
-    return TestClient(app)
+    return TestClient(get_app())
 
 
 @pytest.fixture
@@ -72,8 +72,8 @@ def async_test_client(monkeypatch) -> AsyncClient:
     """
     monkeypatch.setenv('PYCONNECT_CERT', './mycert.pem')
     monkeypatch.setenv('PYCONNECT_CERT_KEY', './mycert.key')
-    from pyconnect.main import app
-    return AsyncClient(app=app, base_url='http://testserver')
+
+    return AsyncClient(app=get_app(), base_url='http://testserver')
 
 
 @pytest.fixture

--- a/tests/routes/test_status.py
+++ b/tests/routes/test_status.py
@@ -29,7 +29,7 @@ async def test_status_get(async_test_client, monkeypatch):
             assert actual_json['elapsed_time'] > 0.0
 
             expected = {
-                'application': 'pyconnect.main:app',
+                'application': 'pyconnect.asgi:app',
                 'application_version': actual_json['application_version'],
                 'is_reload_enabled': False,
                 'nats_status': 'AVAILABLE',


### PR DESCRIPTION
This PR updates the pyConnect application by decoupling the "app" variable from application initialization. This change was made so that test case fixtures and local environments are not coupled to the "app" variable/attribute. A new module, asgi.py, is in place to support running the application in a production environment.

The command to run the app locally is still the same
```python
(venv) tdw@dixons-mbp pyconnect % PYCONNECT_CERT=./local-certs/lfh.pem \
PYCONNECT_CERT_KEY=./local-certs/lfh.key \
UVICORN_RELOAD=True \
python pyconnect/main.py
```

Finally this PR will help us run a "production configuration" in a container using a command similar to
```shell
CMD ["/env/bin/gunicorn", "gino_fastapi_demo.asgi:app", "-b", "0.0.0.0:80", "-k", "uvicorn.workers.UvicornWorker"]
```

resolves #69 