### PR TITLE
Core and FHIR Workflow Tests

### DIFF
--- a/pyconnect/clients/kafka.py
+++ b/pyconnect/clients/kafka.py
@@ -362,8 +362,10 @@ class KafkaCallback():
     """
     Store returned data from the Kafka callback
     """
-    kafka_status = None
-    kafka_result = None
+
+    def __init__(self):
+        self.kafka_status = None
+        self.kafka_result = None
 
     def get_kafka_result(self, err: object, msg: object):
         """

--- a/pyconnect/workflows/core.py
+++ b/pyconnect/workflows/core.py
@@ -14,10 +14,10 @@ from pyconnect.clients.kafka import (get_kafka_producer,
                                      KafkaCallback)
 from pyconnect.clients.nats import get_nats_client
 from pyconnect.config import nats_sync_subject
-from pyconnect.exceptions import (KafkaStorageError,
-                                  LFHError)
+from pyconnect.exceptions import LFHError
 from pyconnect.routes.data import LinuxForHealthDataRecordResponse
 from pyconnect.support.encoding import (encode_from_dict,
+                                        encode_from_str,
                                         decode_to_str,
                                         PyConnectEncoder)
 
@@ -54,7 +54,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
     """
     def __init__(self, **kwargs):
         self.message = kwargs['message']
-        self.data_format = None
+        self.data_format = kwargs.get('data_format', None)
         self.origin_url = kwargs['origin_url']
         self.start_time = None
         self.use_response = False
@@ -62,9 +62,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         self.lfh_exception_topic = 'LFH_EXCEPTION'
         self.lfh_id = kwargs['lfh_id']
 
-
     state = CoreWorkflowDef()
-
 
     @xworkflows.transition('do_validate')
     def validate(self):
@@ -73,7 +71,6 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         """
         pass
 
-
     @xworkflows.transition('do_transform')
     def transform(self):
         """
@@ -81,7 +78,6 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         or FHIR R3 to R4).
         """
         pass
-
 
     @xworkflows.transition('do_persist')
     async def persist(self):
@@ -99,10 +95,16 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         self.message: The python dict for LinuxForHealthDataRecordResponse instance with
             the original object instance in the data field as a byte string
         """
-        data = self.message
-        logging.debug(f'{self.__class__.__name__}: incoming message = {data}')
-        logging.debug(f'{self.__class__.__name__}: incoming message type = {type(data)}')
-        data_encoded = encode_from_dict(data.dict())
+
+        logging.debug(f'{self.__class__.__name__}: incoming message = {self.message}')
+        logging.debug(f'{self.__class__.__name__}: incoming message type = {type(self.message)}')
+
+        if hasattr(self.message, 'dict'):
+            encoded_data = encode_from_dict(self.message.dict())
+        elif isinstance(self.message, dict):
+            encoded_data = encode_from_dict(self.message)
+        else:
+            encoded_data = encode_from_str(self.message)
 
         message = {
             'uuid': str(uuid.uuid4()),
@@ -111,7 +113,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
             'store_date': str(datetime.utcnow().replace(microsecond=0)) + 'Z',
             'consuming_endpoint_url': self.origin_url,
             'data_format': self.data_format,
-            'data': data_encoded
+            'data': encoded_data
 
         }
         response = LinuxForHealthDataRecordResponse(**message)
@@ -133,7 +135,6 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         response = LinuxForHealthDataRecordResponse(**message).dict()
         logging.debug(f'{self.__class__.__name__} persist: outgoing message = {response}')
         self.message = response
-
 
     @xworkflows.transition('do_transmit')
     async def transmit(self, response: Response):
@@ -177,7 +178,6 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
 
             self.use_response = True
 
-
     @xworkflows.transition('do_sync')
     async def synchronize(self):
         """
@@ -186,7 +186,6 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         nats_client = await get_nats_client()
         msg_str = json.dumps(self.message, cls=PyConnectEncoder)
         await nats_client.publish(nats_sync_subject, bytearray(msg_str, 'utf-8'))
-
 
     @xworkflows.transition('handle_error')
     async def error(self, error) -> str:
@@ -222,7 +221,6 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         error = LFHError(**message).json()
         logging.debug(f'{self.__class__.__name__} error: outgoing message = {error}')
         return error
-
 
     async def run(self, response: Response):
         """

--- a/tests/workflows/test_core.py
+++ b/tests/workflows/test_core.py
@@ -1,0 +1,96 @@
+"""
+test_core.py
+
+Tests the processes and transitions defined within the Core Workflow implementation.
+"""
+import pytest
+from pyconnect.workflows import core
+from pyconnect.workflows.core import CoreWorkflow
+import datetime
+from unittest.mock import (AsyncMock,
+                           Mock)
+
+
+@pytest.fixture
+def kafka_callback():
+    class MockCallback:
+        def __init__(self):
+            self.kafka_result = 'CUSTOM:0:0'
+            self.kafka_status = 'success'
+
+        def get_kafka_result(self, err: object, msg: object):
+            pass
+
+    return MockCallback
+
+
+@pytest.fixture
+def workflow() -> CoreWorkflow:
+    config = {
+        'message': {'first_name': 'John', 'last_name': 'Doe'},
+        'origin_url': 'http://localhost:5000/data',
+        'certificate_verify': False,
+        'lfh_id': '90cf887d-eaa0-4997-b2b7-b1e39ae0ec03',
+        'data_format': 'custom'
+    }
+    workflow = CoreWorkflow(**config)
+    workflow.transmit_server = 'https://external-server.com/data'
+    return workflow
+
+
+def test_init(workflow: CoreWorkflow):
+    """
+    Tests CoreWorkflow.__init__ and the state transition.
+    :param workflow: The CoreWorkflow fixture
+    """
+    assert workflow.message == {'first_name': 'John', 'last_name': 'Doe'}
+    assert workflow.data_format == 'custom'
+    assert workflow.origin_url == 'http://localhost:5000/data'
+    assert workflow.start_time is None
+    assert workflow.use_response is False
+    assert workflow.verify_certs is False
+    assert workflow.lfh_exception_topic == 'LFH_EXCEPTION'
+    assert workflow.lfh_id == '90cf887d-eaa0-4997-b2b7-b1e39ae0ec03'
+
+    assert workflow.state == 'parse'
+
+
+@pytest.mark.asyncio
+async def test_manual_flow_with_transmit(workflow: CoreWorkflow,
+                                         monkeypatch,
+                                         kafka_callback,
+                                         mock_httpx_client):
+    """
+    Manually tests CoreWorkflow state transitions where data is transmitted
+    """
+    workflow.start_time = datetime.datetime.utcnow()
+    nats_mock = AsyncMock()
+
+    with monkeypatch.context() as m:
+        m.setattr(core, 'get_kafka_producer', Mock(return_value=AsyncMock()))
+        m.setattr(core, 'KafkaCallback', kafka_callback)
+        m.setattr(core, 'AsyncClient', mock_httpx_client)
+        m.setattr(core, 'get_nats_client', AsyncMock(return_value=nats_mock))
+
+        workflow.validate()
+        assert workflow.state.name == 'validate'
+
+        workflow.transform()
+        assert workflow.state.name == 'transform'
+
+        await workflow.persist()
+        assert workflow.state.name == 'persist'
+        assert workflow.message['elapsed_storage_time'] > 0
+        assert workflow.message['elapsed_total_time'] > 0
+        assert workflow.message['data_record_location'] == 'CUSTOM:0:0'
+        assert workflow.message['status'] == 'success'
+
+        await workflow.transmit(Mock())
+        assert workflow.state.name == 'transmit'
+        assert workflow.message['transmit_date'] is not None
+        assert workflow.message['elapsed_transmit_time'] > 0
+        assert workflow.use_response is True
+
+        await workflow.synchronize()
+        assert workflow.state.name == 'sync'
+        nats_mock.publish.assert_called_once()

--- a/tests/workflows/test_core.py
+++ b/tests/workflows/test_core.py
@@ -34,7 +34,6 @@ def workflow() -> CoreWorkflow:
         'data_format': 'custom'
     }
     workflow = CoreWorkflow(**config)
-    workflow.transmit_server = 'https://external-server.com/data'
     return workflow
 
 
@@ -56,12 +55,21 @@ def test_init(workflow: CoreWorkflow):
 
 
 @pytest.mark.asyncio
-async def test_manual_flow_with_transmit(workflow: CoreWorkflow,
-                                         monkeypatch,
-                                         kafka_callback,
-                                         mock_httpx_client):
+async def test_manual_flow(workflow: CoreWorkflow,
+                           monkeypatch,
+                           kafka_callback,
+                           mock_httpx_client):
     """
-    Manually tests CoreWorkflow state transitions where data is transmitted
+    Manually tests CoreWorkflow state transitions.
+
+    Transitions are tested in a single test case since the workflow model requires methods to be executed
+    sequentially in a specific order. The testing order mirrors the execution order provider in
+    CoreWorkflow.run.
+
+    :param workflow: The CoreWorkflow fixture
+    :param monkeypatch: Pytest monkeypatch fixture
+    :param kafka_callback: KafkaCallback fixture
+    :param mock_httpx_client: Mock HTTPX Client fixture
     """
     workflow.start_time = datetime.datetime.utcnow()
     nats_mock = AsyncMock()
@@ -85,6 +93,7 @@ async def test_manual_flow_with_transmit(workflow: CoreWorkflow,
         assert workflow.message['data_record_location'] == 'CUSTOM:0:0'
         assert workflow.message['status'] == 'success'
 
+        workflow.transmit_server = 'https://external-server.com/data'
         await workflow.transmit(Mock())
         assert workflow.state.name == 'transmit'
         assert workflow.message['transmit_date'] is not None
@@ -94,3 +103,107 @@ async def test_manual_flow_with_transmit(workflow: CoreWorkflow,
         await workflow.synchronize()
         assert workflow.state.name == 'sync'
         nats_mock.publish.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_manual_flow_transmit_disabled(workflow: CoreWorkflow,
+                                             monkeypatch,
+                                             kafka_callback,
+                                             mock_httpx_client):
+    """
+    Manually tests CoreWorkflow state transitions where transmission is disabled
+
+    Transitions are tested in a single test case since the workflow model requires methods to be executed
+    sequentially in a specific order. The testing order mirrors the execution order provider in
+    CoreWorkflow.run.
+
+    :param workflow: The CoreWorkflow fixture
+    :param monkeypatch: Pytest monkeypatch fixture
+    :param kafka_callback: KafkaCallback fixture
+    :param mock_httpx_client: Mock HTTPX Client fixture
+    """
+    workflow.start_time = datetime.datetime.utcnow()
+
+    with monkeypatch.context() as m:
+        m.setattr(core, 'get_kafka_producer', Mock(return_value=AsyncMock()))
+        m.setattr(core, 'KafkaCallback', kafka_callback)
+        m.setattr(core, 'AsyncClient', mock_httpx_client)
+
+        workflow.validate()
+        assert workflow.state.name == 'validate'
+
+        workflow.transform()
+        assert workflow.state.name == 'transform'
+
+        await workflow.persist()
+        assert workflow.state.name == 'persist'
+
+        await workflow.transmit(Mock())
+        assert workflow.state.name == 'transmit'
+        assert workflow.message['transmit_date'] is None
+        assert workflow.message['elapsed_transmit_time'] is None
+        assert workflow.use_response is False
+
+
+@pytest.mark.asyncio
+async def test_run_flow(workflow: CoreWorkflow,
+                        monkeypatch,
+                        kafka_callback,
+                        mock_httpx_client):
+    """
+    Tests the CoreWorkflow.run method.
+
+    :param workflow: The CoreWorkflow fixture
+    :param monkeypatch: Pytest monkeypatch fixture
+    :param kafka_callback: KafkaCallback fixture
+    :param mock_httpx_client: Mock HTTPX Client fixture
+    """
+    workflow.start_time = datetime.datetime.utcnow()
+
+    with monkeypatch.context() as m:
+        m.setattr(core, 'get_kafka_producer', Mock(return_value=AsyncMock()))
+        m.setattr(core, 'KafkaCallback', kafka_callback)
+        m.setattr(core, 'AsyncClient', mock_httpx_client)
+        m.setattr(core, 'get_nats_client', AsyncMock(return_value=AsyncMock()))
+
+        actual_value = await workflow.run(Mock())
+        assert actual_value['consuming_endpoint_url'] == 'http://localhost:5000/data'
+        assert actual_value['creation_date'] is not None
+        assert actual_value['data'] == 'eyJmaXJzdF9uYW1lIjogIkpvaG4iLCAibGFzdF9uYW1lIjogIkRvZSJ9'
+        assert actual_value['data_format'] == 'custom'
+        assert actual_value['data_record_location'] == 'CUSTOM:0:0'
+        assert actual_value['elapsed_storage_time'] > 0
+        assert actual_value['elapsed_total_time'] > 0
+        assert actual_value['elapsed_transmit_time'] is None
+        assert actual_value['lfh_id'] is not None
+        assert actual_value['status'] == 'success'
+        assert actual_value['store_date'] is not None
+        assert actual_value['target_endpoint_url'] is None
+        assert actual_value['transmit_date'] is None
+        assert actual_value['uuid'] is not None
+
+
+@pytest.mark.asyncio
+async def test_run_flow_error(workflow: CoreWorkflow,
+                              monkeypatch,
+                              kafka_callback,
+                              mock_httpx_client):
+    """
+    Tests the CoreWorkflow.run method when an exception occurs
+
+    :param workflow: The CoreWorkflow fixture
+    :param monkeypatch: Pytest monkeypatch fixture
+    :param kafka_callback: KafkaCallback fixture
+    :param mock_httpx_client: Mock HTTPX Client fixture
+    """
+    workflow.start_time = datetime.datetime.utcnow()
+    workflow.validate = Mock(side_effect=Exception('test exception'))
+
+    with monkeypatch.context() as m:
+        m.setattr(core, 'get_kafka_producer', Mock(return_value=AsyncMock()))
+        m.setattr(core, 'KafkaCallback', kafka_callback)
+        m.setattr(core, 'AsyncClient', mock_httpx_client)
+        m.setattr(core, 'get_nats_client', AsyncMock(return_value=AsyncMock()))
+
+        with pytest.raises(Exception):
+            await workflow.run(Mock())

--- a/tests/workflows/test_fhir.py
+++ b/tests/workflows/test_fhir.py
@@ -1,0 +1,57 @@
+"""
+test_fhir.py
+
+Tests the processes and transitions defined within the FHIR Workflow implementation.
+"""
+import pytest
+from pydantic import ValidationError
+
+from pyconnect.exceptions import MissingFhirResourceType, FhirValidationError
+from pyconnect.workflows.fhir import FhirWorkflow
+
+
+@pytest.fixture
+def workflow() -> FhirWorkflow:
+    config = {
+        'message': {'resourceType': 'Patient', 'id': '001', 'active': True},
+        'origin_url': 'http://localhost:5000/fhir',
+        'certificate_verify': False,
+        'lfh_id': '90cf887d-eaa0-4997-b2b7-b1e39ae0ec03',
+    }
+    workflow = FhirWorkflow(**config)
+    return workflow
+
+
+def test_validate(workflow: FhirWorkflow):
+    """
+    Tests FhirWorkflow.validate where the resource is valid
+    """
+    workflow.validate()
+    assert workflow.data_format == 'PATIENT'
+
+
+def test_validate_missing_resource_type(workflow: FhirWorkflow):
+    """
+    Tests FhirWorkflow.validate where the resource is missing
+    """
+    del workflow.message['resourceType']
+    with pytest.raises(MissingFhirResourceType):
+        workflow.validate()
+
+
+def test_validate_mismatched_resource_type(workflow: FhirWorkflow):
+    """
+    Tests FhirWorkflow.validate where the resourceType in the message does not match the actual resource
+    """
+    workflow.message['resourceType'] = 'Encounter'
+    with pytest.raises(ValidationError):
+        workflow.validate()
+
+
+def test_validate_invalid_resource_type(workflow: FhirWorkflow):
+    """
+    Tests FhirWorkflow.validate where the resourceType in the message does not match the actual resource
+    """
+    workflow.message['resourceType'] = 'NoSuchResourceName'
+    with pytest.raises(FhirValidationError):
+        workflow.validate()


### PR DESCRIPTION
This PR adds unit tests for the CoreWorkflow and FhirWorkflow implementations. Additional changes include:

- CoreWorkflow.persist encodes a message based on it's type, rather than assuming it's a Pydantic object. This will be useful for formats such as HL7 where we may not have a Pydantic model.
- Migrated class attributes in KafkaCallback to instance attributes.
- Addresses minor linting issues in CoreWorkflow

resolves #97 , #70 , #75 