### PR TITLE
Fixed NATS subscriptions

### DIFF
--- a/pyconnect/clients/kafka.py
+++ b/pyconnect/clients/kafka.py
@@ -342,7 +342,7 @@ def kafka_sync_msg_handler(msg: Message):
     logger.debug(f'lfh_sync_msg_handler: posted message to {destination_url}  result = {result}')
 
 
-def remove_kafka_listeners():
+def stop_kafka_listeners():
     """
     Stop all Kafka listeners
     """

--- a/pyconnect/clients/nats.py
+++ b/pyconnect/clients/nats.py
@@ -13,36 +13,38 @@ from pyconnect.clients.kafka import (get_kafka_producer,
 from pyconnect.config import (get_settings,
                               nats_sync_subject,
                               kafka_sync_topic)
-from typing import Optional
+from typing import (List,
+                    Optional)
 
 
 logger = logging.getLogger(__name__)
 nats_client = None
-nats_subscribers = []
+nats_clients = []
 
 
 async def create_nats_subscribers():
     """
-    Create an instance of each NATS subscriber.  Add additional subscribers as needed.
+    Create NATS subscribers.  Add additional subscribers as needed.
     """
-    sid = await start_sync_event_subscriber()
-    nats_subscribers.append(sid)
+    await start_sync_event_subscribers()
 
 
-async def start_sync_event_subscriber():
+async def start_sync_event_subscribers():
     """
-    Subscribes to EVENTS.responses NATS messages from the local LFH
-    and any defined remote LFH instances.
+    Create a NATS subscriber for 'nats_sync_subject' for each NATS server defined by
+    'nats_sync_subscribers' in config.py.
     """
-    nats_client = await get_nats_client()
-    sid = await nats_client.subscribe(nats_sync_subject, cb=nats_sync_event_handler)
-    logger.debug(f'start_sync_event_subscriber: subscribed to NATS subject {nats_sync_subject}')
-    return sid
+    settings = get_settings()
+    for server in settings.nats_sync_subscribers:
+        nats_client = await create_nats_client(server)
+        await nats_client.subscribe(nats_sync_subject, cb=nats_sync_event_handler)
+        nats_clients.append(nats_client)
+        logger.debug(f'start_sync_event_subscribers: subscribed {server} to NATS subject {nats_sync_subject}')
 
 
 async def nats_sync_event_handler(msg: Msg):
     """
-    Callback for NATS EVENTS.sync messages
+    Callback for NATS 'nats_sync_subject' messages
     """
     subject = msg.subject
     reply = msg.reply
@@ -64,34 +66,52 @@ async def nats_sync_event_handler(msg: Msg):
     logger.debug(f'nats_sync_event_handler: stored LFH message in Kafka for replay at {kafka_cb.kafka_result}')
 
 
-async def remove_nats_subscribers():
-    """
-    Stop all NATS subscriptions prior to shutdown
-    """
-    nats_client = await get_nats_client()
-    for subscriber in nats_subscribers:
-        await nats_client.unsubscribe(subscriber)
+async def stop_nats_clients():
+    '''
+    Gracefully stop all NATS clients prior to shutdown, including
+    unsubscribing from all subscriptions.
+    '''
+    for client in nats_clients:
+        await client.drain()
 
 
 async def get_nats_client() -> Optional[NatsClient]:
     """
+    Create or return a NATS client for publishing NATS messages to the local
+    NATS server or cluster defined by 'nats_servers' in config.py.
+
     :return: a connected NATS client instance
     """
     global nats_client
 
     if not nats_client:
         settings = get_settings()
+        nats_client = await create_nats_client(settings.nats_servers)
+        nats_clients.append(nats_client)
 
-        ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
-        ssl_ctx.load_verify_locations(settings.nats_rootCA_file)
+    return nats_client
 
-        nats_client = NatsClient()
-        await nats_client.connect(
-            servers=settings.nats_servers,
-            loop=get_running_loop(),
-            tls=ssl_ctx,
-            allow_reconnect=settings.nats_allow_reconnect,
-            max_reconnect_attempts=settings.nats_max_reconnect_attempts)
-        logger.debug(f'get_nats_client: NATS client started for servers = {settings.nats_servers}')
+
+async def create_nats_client(servers: List[str]) -> Optional[NatsClient]:
+    """
+    Create a NATS client for any NATS server or NATS cluster.
+
+    :param servers: List of one or more NATS servers.  If multiple servers are
+    provided, they should be in the same NATS cluster.
+    :return: a connected NATS client instance
+    """
+    settings = get_settings()
+
+    ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+    ssl_ctx.load_verify_locations(settings.nats_rootCA_file)
+
+    nats_client = NatsClient()
+    await nats_client.connect(
+        servers=servers,
+        loop=get_running_loop(),
+        tls=ssl_ctx,
+        allow_reconnect=settings.nats_allow_reconnect,
+        max_reconnect_attempts=settings.nats_max_reconnect_attempts)
+    logger.debug(f'create_nats_client: NATS client created for servers = {servers}')
 
     return nats_client

--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -50,7 +50,7 @@ class Settings(BaseSettings):
 
     # nats
     nats_servers: List[str] = ['tls://localhost:4222']
-    nats_sync_subscribers: List[str] = ['tls://localhost:4222']
+    nats_sync_subscribers: List[str] = []
     nats_allow_reconnect: bool = True
     nats_max_reconnect_attempts: int = 10
     nats_rootCA_file: str = local_certs_path + '/rootCA.pem'

--- a/pyconnect/config.py
+++ b/pyconnect/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
 
     # nats
     nats_servers: List[str] = ['tls://localhost:4222']
+    nats_sync_subscribers: List[str] = ['tls://localhost:4222']
     nats_allow_reconnect: bool = True
     nats_max_reconnect_attempts: int = 10
     nats_rootCA_file: str = local_certs_path + '/rootCA.pem'

--- a/pyconnect/server_handlers.py
+++ b/pyconnect/server_handlers.py
@@ -13,7 +13,7 @@ from pyconnect.clients.kafka import (get_kafka_producer,
                                      remove_kafka_listeners)
 from pyconnect.clients.nats import (create_nats_subscribers,
                                     get_nats_client,
-                                    remove_nats_subscribers)
+                                    stop_nats_clients)
 
 
 logger = logging.getLogger(__name__)
@@ -110,10 +110,7 @@ async def close_internal_clients() -> None:
     kafka_producer = get_kafka_producer()
     kafka_producer.close()
 
-    await remove_nats_subscribers()
-    nats_client = await get_nats_client()
-    await nats_client.close()
-
+    await stop_nats_clients()
     remove_kafka_listeners()
 
 

--- a/pyconnect/server_handlers.py
+++ b/pyconnect/server_handlers.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 from pyconnect.config import get_settings
 from pyconnect.clients.kafka import (get_kafka_producer,
                                      create_kafka_listeners,
-                                     remove_kafka_listeners)
+                                     stop_kafka_listeners)
 from pyconnect.clients.nats import (create_nats_subscribers,
                                     get_nats_client,
                                     stop_nats_clients)
@@ -111,7 +111,7 @@ async def close_internal_clients() -> None:
     kafka_producer.close()
 
     await stop_nats_clients()
-    remove_kafka_listeners()
+    stop_kafka_listeners()
 
 
 async def http_exception_handler(request: Request, exc: HTTPException):


### PR DESCRIPTION
Changes:

* Created a NATS subscriber for the local NATS server or cluster *plus* a NATS subscriber for each additional NATS server to receive sync messages from.
* Added a separate entry to config.py to differentiate the local NATS server or cluster IP(s) from any additional NATS servers to subscribe to, providing the ability to use the local NATS IPs as a pool if using a NATS cluster.