### PR TITLE
Resolving warnings with awaitable code for the status check

### DIFF
--- a/pyconnect/support/availability.py
+++ b/pyconnect/support/availability.py
@@ -33,7 +33,7 @@ async def ping_host(hostname: str, port: int) -> bool:
         return True
     finally:
         if writer is not None:
-            writer.close()
+            await writer.close()
 
 
 def get_host_ports(service_setting: List[str]) -> List[tuple]:

--- a/tests/support/test_availability.py
+++ b/tests/support/test_availability.py
@@ -57,7 +57,7 @@ def test_get_host_ports():
 
 
 @pytest.mark.asyncio
-def test_is_service_available(monkeypatch):
+async def test_is_service_available(monkeypatch):
     """
     Validates that is_service_available returns True for valid connections, False when an error occurs.
     The underlying function used to confirm availability, asyncio.open_connection,
@@ -68,11 +68,12 @@ def test_is_service_available(monkeypatch):
         mock = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
         m.setattr(asyncio, 'open_connection', mock)
         service_setting = ['https://localhost:8080', 'tls://otherhost:8080']
-        actual_result = asyncio.run(is_service_available(service_setting))
+        actual_result = await is_service_available(service_setting)
+        # actual_result = asyncio.run(is_service_available(service_setting))
         assert actual_result is True
 
         mock = AsyncMock(side_effect=OSError)
         m.setattr(asyncio, 'open_connection', mock)
         service_setting = ['https://localhost:9090', 'tls://otherhost:8080']
-        actual_result = asyncio.run(is_service_available(service_setting))
+        actual_result = await is_service_available(service_setting)
         assert actual_result is False


### PR DESCRIPTION
This PR resolves some "warning" conditions around the /status check endpoint