### PR TITLE
Add GitHub Actions To Test Docker Build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,9 +13,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - name: Build
         uses: docker/build-push-action@v2
         with:
           context: .
+          build-args: APPLICATION_BUILD_CERT_PATH=./local-certs
           push: false
           tags: linuxforhealth/connect:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,6 +32,7 @@ jobs:
           build-args: APPLICATION_BUILD_CERT_PATH=./local-certs
           push: false
           tags: linuxforhealth/connect:latest
+          platforms: linux/amd64,linux/arm64,linux/s390x
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,23 +8,14 @@ on:
     branches: [ main ]
 
 jobs:
-  docker:
+  build-image:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Build
+      - name: Build
         uses: docker/build-push-action@v2
         with:
           context: .
-          platforms: linux/amd64,linux/arm64, linux/s390x
           push: false
           tags: linuxforhealth/connect:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,5 @@
-# builds a multi-platform pyConnect image
-name: pyConnect Multi-Platform Image Build
+# validates the pyConnect image build process
+name: Validates the pyConnect image build process
 
 on:
   push:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Create Certificate and Key Placeholders
+        run: |
+          touch ./local-certs/placeholder.pem && touch ./local-certs/placeholder.key
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,7 +32,6 @@ jobs:
           build-args: APPLICATION_BUILD_CERT_PATH=./local-certs
           push: false
           tags: linuxforhealth/connect:latest
-          platforms: linux/amd64,linux/arm64,linux/s390x
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,30 @@
+# builds a multi-platform pyConnect image
+name: pyConnect Multi-Platform Image Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64, linux/s390x
+          push: false
+          tags: linuxforhealth/connect:latest

--- a/.github/workflows/pyconnect-image-build.yml
+++ b/.github/workflows/pyconnect-image-build.yml
@@ -1,5 +1,5 @@
 # validates the pyConnect image build process
-name: Validates the pyConnect image build process
+name: pyConnect Image Build
 
 on:
   push:
@@ -30,6 +30,7 @@ jobs:
         with:
           context: .
           build-args: APPLICATION_BUILD_CERT_PATH=./local-certs
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: false
           tags: linuxforhealth/connect:latest
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/pyconnect-image-build.yml
+++ b/.github/workflows/pyconnect-image-build.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           context: .
           build-args: APPLICATION_BUILD_CERT_PATH=./local-certs
-          platforms: linux/amd64,linux/arm64,linux/s390x
           push: false
           tags: linuxforhealth/connect:latest
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9.4-alpine3.13
 
 ARG APPLICATION_BUILD_CERT_PATH="./local-certs"
 ENV LIBRDKAFKA_VERSION="v1.6.1"
-ENV APPLICATION_CERT_PATH="/usr/local/share/ca-certificates"
+ENV APPLICATION_CERT_PATH="/usr/local/share/ca-certificates/"
 
 RUN apk update && \
     apk add --no-cache --virtual .dev-packages build-base curl bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.9.4-alpine3.13
 
 ARG APPLICATION_BUILD_CERT_PATH="./local-certs"
 ENV LIBRDKAFKA_VERSION="v1.6.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,13 @@ RUN apk update && \
 
 # install certificates and keys
 # certificates are in base64-encoded (PEM) format
-COPY ${APPLICATION_BUILD_CERT_PATH}/*.pem ${APPLICATION_CERT_PATH}
-COPY ${APPLICATION_BUILD_CERT_PATH}/*.key ${APPLICATION_CERT_PATH}
-RUN chmod 644 ${APPLICATION_CERT_PATH}/* && update-ca-certificates
+COPY $APPLICATION_BUILD_CERT_PATH/*.pem $APPLICATION_CERT_PATH
+RUN chmod 644 $APPLICATION_CERT_PATH/*.pem
+
+COPY $APPLICATION_BUILD_CERT_PATH/*.key $APPLICATION_CERT_PATH
+RUN chmod 644 $APPLICATION_CERT_PATH/*.key
+
+RUN update-ca-certificates
 
 # installing librdkafka from source as alpine package repositories may lag behind python confluent kafka requirements
 # librdkafka installation procedure is attributed to https://github.com/confluentinc/confluent-kafka-python

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY --chown=lfh:lfh ./pyconnect ./pyconnect
 COPY --chown=lfh:lfh ./setup.py setup.py
 COPY --chown=lfh:lfh ./README.md README.md
 COPY --chown=lfh:lfh ./logging.yaml logging.yaml
-RUN pip install --user -e .
+RUN python -m pip install --user -e .
 
 USER root
 RUN apk del .dev-packages


### PR DESCRIPTION
This PR adds a new GitHub action to support building the pyConnect or "connect" image on amd64, arm64, and s390x. Note that the action does not support pushing the image to docker hub. We can update the action to do this in a future iteration once we have cleaned up the old "java connect" images.