### PR TITLE
Internal Server Error on /status Endpoint

### DIFF
--- a/pyconnect/support/availability.py
+++ b/pyconnect/support/availability.py
@@ -32,8 +32,8 @@ async def ping_host(hostname: str, port: int) -> bool:
     else:
         return True
     finally:
-        if writer is not None:
-            await writer.close()
+        if writer:
+            writer.close()
 
 
 def get_host_ports(service_setting: List[str]) -> List[tuple]:

--- a/tests/support/test_availability.py
+++ b/tests/support/test_availability.py
@@ -4,7 +4,8 @@ test_availability.py
 Tests pyConnect service/host availability functions
 """
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import (AsyncMock,
+                           Mock)
 import pytest
 from pyconnect.support.availability import (get_host_ports,
                                             is_service_available,
@@ -20,7 +21,7 @@ def test_ping_host(monkeypatch):
     :param monkeypatch:
     """
     with monkeypatch.context() as m:
-        mock = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+        mock = AsyncMock(return_value=(Mock(), Mock()))
         m.setattr(asyncio, 'open_connection', mock)
         actual_result = asyncio.run(ping_host('some-server', 8080))
         assert actual_result is True
@@ -65,11 +66,10 @@ async def test_is_service_available(monkeypatch):
     """
     with monkeypatch.context() as m:
 
-        mock = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+        mock = AsyncMock(return_value=(Mock(), Mock()))
         m.setattr(asyncio, 'open_connection', mock)
         service_setting = ['https://localhost:8080', 'tls://otherhost:8080']
         actual_result = await is_service_available(service_setting)
-        # actual_result = asyncio.run(is_service_available(service_setting))
         assert actual_result is True
 
         mock = AsyncMock(side_effect=OSError)


### PR DESCRIPTION
This PR updates some issues around "await able" code and test cases . 

The `open_connection` method used in the availability module was "awaiting" the call to `writer.close()` which is incorrect. The PR updates the code so that open_connect is awaitable but does not have awaitable returns.