### PR TITLE
Support FHIR Server In Deployment Profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,7 +136,7 @@ services:
       - ./private-ipfs-network/.ipfs/swarm.key:/data/ipfs/swarm.key
       - ./private-ipfs-network/init.sh:/usr/local/bin/start_ipfs
   ibm-fhir:
-    profiles: ["fhir"]
+    profiles: ["fhir", "deployment"]
     image: docker.io/ibmcom/ibm-fhir-server:4.4.0
     networks:
       - main


### PR DESCRIPTION
This PR updates the FHIR server "service" configuration in pyConnect's docker compose file to support the new "deployment" profile. The deployment profile starts the following services:

- Zookeeper
- Kafka
- NATS
- Connect
- IBM FHIR Server

```shell
docker-compose --profile deployment up -d
```