### PR TITLE
Add FHIR-R4 prefix to FHIR Topic Names

### DIFF
--- a/pyconnect/workflows/fhir.py
+++ b/pyconnect/workflows/fhir.py
@@ -32,7 +32,7 @@ class FhirWorkflow(CoreWorkflow):
 
         try:
             self.message = construct_fhir_element(resource_type, self.message)
-            self.data_format = resource_type.upper()
+            self.data_format = f'FHIR-R4_{resource_type.upper()}'
         except LookupError as le:
             logging.exception(le)
             raise FhirValidationError(str(le))

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -203,9 +203,9 @@ async def test_fhir_post(async_test_client,
         assert 'elapsed_total_time' in actual_json
 
         assert actual_json['consuming_endpoint_url'] == '/fhir/Encounter'
-        assert actual_json['data_format'] == 'ENCOUNTER'
+        assert actual_json['data_format'] == 'FHIR-R4_ENCOUNTER'
         assert actual_json['status'] == 'success'
-        assert actual_json['data_record_location'] == 'ENCOUNTER:0:0'
+        assert actual_json['data_record_location'] == 'FHIR-R4_ENCOUNTER:0:0'
 
 
 @pytest.mark.asyncio

--- a/tests/workflows/test_fhir.py
+++ b/tests/workflows/test_fhir.py
@@ -27,7 +27,7 @@ def test_validate(workflow: FhirWorkflow):
     Tests FhirWorkflow.validate where the resource is valid
     """
     workflow.validate()
-    assert workflow.data_format == 'PATIENT'
+    assert workflow.data_format == 'FHIR-R4_PATIENT'
 
 
 def test_validate_missing_resource_type(workflow: FhirWorkflow):


### PR DESCRIPTION
This PR updates the FHIR Workflow class to add a prefix, "FHIR-R4" to the generated topic name. So we'll use topics such as "FHIR-R4_PATIENT" rather than "PATIENT". This level of granularity will help us direct the appropriate downstream process to do the "correct" conversions.