### PR TITLE
Add the LFH msg id as header in transmit responses

### DIFF
--- a/pyconnect/workflows/core.py
+++ b/pyconnect/workflows/core.py
@@ -182,6 +182,9 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
                 if key not in ['Content-Length', 'Content-Language', 'Date']:
                     response.headers[key] = value
 
+            # Set original LFH message uuid in response header
+            response.headers['LinuxForHealth-MessageId'] = str(self.message['uuid'])
+
             self.use_response = True
 
     @xworkflows.transition('do_sync')

--- a/tests/workflows/test_core.py
+++ b/tests/workflows/test_core.py
@@ -3,6 +3,7 @@ test_core.py
 
 Tests the processes and transitions defined within the Core Workflow implementation.
 """
+from fastapi import Response
 import pyconnect.clients.nats as nats
 import pytest
 from pyconnect.workflows import core
@@ -95,7 +96,7 @@ async def test_manual_flow(workflow: CoreWorkflow,
         assert workflow.message['status'] == 'success'
 
         workflow.transmit_server = 'https://external-server.com/data'
-        await workflow.transmit(Mock())
+        await workflow.transmit(Response())
         assert workflow.state.name == 'transmit'
         assert workflow.message['transmit_date'] is not None
         assert workflow.message['elapsed_transmit_time'] > 0

--- a/tests/workflows/test_core.py
+++ b/tests/workflows/test_core.py
@@ -96,11 +96,13 @@ async def test_manual_flow(workflow: CoreWorkflow,
         assert workflow.message['status'] == 'success'
 
         workflow.transmit_server = 'https://external-server.com/data'
-        await workflow.transmit(Response())
+        response = Response()
+        await workflow.transmit(response)
         assert workflow.state.name == 'transmit'
         assert workflow.message['transmit_date'] is not None
         assert workflow.message['elapsed_transmit_time'] > 0
         assert workflow.use_response is True
+        assert response.headers['LinuxForHealth-MessageId'] is not None
 
         await workflow.synchronize()
         assert workflow.state.name == 'sync'


### PR DESCRIPTION
When returning the response from a transmit to an external server, the LFH message uuid for the original message is now returned in the 'LinuxForHealth-MessageId' header.