### PR TITLE
Added trace log level

### DIFF
--- a/connect/clients/kafka.py
+++ b/connect/clients/kafka.py
@@ -15,7 +15,7 @@ from confluent_kafka import (
     TopicPartition,
 )
 from confluent_kafka.admin import AdminClient, NewTopic
-from connect.config import get_settings, kafka_sync_topic
+from connect.config import get_settings, kafka_sync_topic, TRACE
 from connect.exceptions import KafkaMessageNotFoundError, KafkaStorageError
 from threading import Thread
 from typing import Callable, List, Optional
@@ -187,7 +187,8 @@ class ConfluentAsyncKafkaConsumer:
             #     message = combine_segments(msg.value(), self._generate_header_dictionary(msg.headers()))
 
             if message is not None:
-                logger.info(
+                logger.log(
+                    TRACE,
                     f"Found message for topic_name - {self.topic_name}, partition - {self.partition} "
                     f"and offset - {self.offset}. Invoking callback_method - {callback_method}"
                 )
@@ -286,7 +287,8 @@ class ConfluentAsyncKafkaListener:
             error_code = msg.error().code() if msg and msg.error() else None
             if error_code == KafkaError._PARTITION_EOF:
                 # End of partition event
-                logger.debug(
+                logger.log(
+                    TRACE,
                     f"Listener: {msg.topic()} [{msg.partition()}] reached end, offset {msg.offset()}"
                 )
             elif error_code:
@@ -391,7 +393,8 @@ class KafkaCallback:
         else:
             self.kafka_status = "success"
             self.kafka_result = f"{msg.topic()}:{msg.partition()}:{msg.offset()}"
-            logger.debug(
+            logger.log(
+                TRACE,
                 f"Produced record to topic {msg.topic()} "
                 f"partition [{msg.partition()}] @ offset {msg.offset()}"
             )

--- a/connect/clients/kafka.py
+++ b/connect/clients/kafka.py
@@ -190,7 +190,7 @@ class ConfluentAsyncKafkaConsumer:
                 logger.log(
                     TRACE,
                     f"Found message for topic_name - {self.topic_name}, partition - {self.partition} "
-                    f"and offset - {self.offset}. Invoking callback_method - {callback_method}"
+                    f"and offset - {self.offset}. Invoking callback_method - {callback_method}",
                 )
 
                 return await callback_method(message)
@@ -289,7 +289,7 @@ class ConfluentAsyncKafkaListener:
                 # End of partition event
                 logger.log(
                     TRACE,
-                    f"Listener: {msg.topic()} [{msg.partition()}] reached end, offset {msg.offset()}"
+                    f"Listener: {msg.topic()} [{msg.partition()}] reached end, offset {msg.offset()}",
                 )
             elif error_code:
                 # other error
@@ -396,5 +396,5 @@ class KafkaCallback:
             logger.log(
                 TRACE,
                 f"Produced record to topic {msg.topic()} "
-                f"partition [{msg.partition()}] @ offset {msg.offset()}"
+                f"partition [{msg.partition()}] @ offset {msg.offset()}",
             )

--- a/connect/clients/nats.py
+++ b/connect/clients/nats.py
@@ -69,8 +69,7 @@ async def nats_sync_event_handler(msg: Msg):
     reply = msg.reply
     data = msg.data.decode()
     logger.log(
-        TRACE,
-        f"nats_sync_event_handler: received a message on {subject} {reply}"
+        TRACE, f"nats_sync_event_handler: received a message on {subject} {reply}"
     )
 
     # if the message is from our local LFH, don't store in kafka
@@ -78,7 +77,7 @@ async def nats_sync_event_handler(msg: Msg):
     if get_settings().connect_lfh_id == message["lfh_id"]:
         logger.log(
             TRACE,
-            "nats_sync_event_handler: detected local LFH message, not storing in kafka"
+            "nats_sync_event_handler: detected local LFH message, not storing in kafka",
         )
         return
 
@@ -90,7 +89,7 @@ async def nats_sync_event_handler(msg: Msg):
     )
     logger.log(
         TRACE,
-        f"nats_sync_event_handler: stored msg in kafka topic {kafka_sync_topic} at {kafka_cb.kafka_result}"
+        f"nats_sync_event_handler: stored msg in kafka topic {kafka_sync_topic} at {kafka_cb.kafka_result}",
     )
 
     # process the message into the local store
@@ -110,7 +109,7 @@ async def nats_sync_event_handler(msg: Msg):
     location = result["data_record_location"]
     logger.log(
         TRACE,
-        f"nats_sync_event_handler: replayed nats sync message, data record location = {location}"
+        f"nats_sync_event_handler: replayed nats sync message, data record location = {location}",
     )
 
 

--- a/connect/clients/nats.py
+++ b/connect/clients/nats.py
@@ -70,7 +70,7 @@ async def nats_sync_event_handler(msg: Msg):
     data = msg.data.decode()
     logger.log(
         TRACE,
-        f"nats_sync_event_handler: received a message on {subject} {reply}: {data}"
+        f"nats_sync_event_handler: received a message on {subject} {reply}"
     )
 
     # if the message is from our local LFH, don't store in kafka

--- a/connect/config.py
+++ b/connect/config.py
@@ -22,6 +22,9 @@ host_name = socket.gethostname()
 nats_sync_subject = "EVENTS.sync"
 kafka_sync_topic = "LFH_SYNC"
 
+# set TRACE log level below DEBUG
+TRACE = 5
+
 
 class Settings(BaseSettings):
     """

--- a/connect/config.py
+++ b/connect/config.py
@@ -21,7 +21,6 @@ import socket
 host_name = socket.gethostname()
 nats_sync_subject = "EVENTS.sync"
 kafka_sync_topic = "LFH_SYNC"
-
 # set TRACE log level below DEBUG
 TRACE = 5
 

--- a/connect/server_handlers.py
+++ b/connect/server_handlers.py
@@ -6,7 +6,7 @@ import yaml
 from yaml import YAMLError
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
-from connect.config import get_settings
+from connect.config import get_settings, TRACE
 from connect.clients.kafka import (
     get_kafka_producer,
     create_kafka_listeners,
@@ -28,9 +28,9 @@ def configure_logging() -> None:
     Logging configuration is parsed from the setting/environment variable LOGGING_CONFIG_PATH, if present.
     If LOGGING_CONFIG_PATH is not found, a basic config is applied.
     """
-
     def apply_basic_config():
         """Applies a basic config for console logging"""
+        logging.addLevelName(TRACE, 'TRACE')
         logging.basicConfig(
             stream=sys.stdout,
             level=logging.INFO,

--- a/connect/server_handlers.py
+++ b/connect/server_handlers.py
@@ -28,9 +28,10 @@ def configure_logging() -> None:
     Logging configuration is parsed from the setting/environment variable LOGGING_CONFIG_PATH, if present.
     If LOGGING_CONFIG_PATH is not found, a basic config is applied.
     """
+
     def apply_basic_config():
         """Applies a basic config for console logging"""
-        logging.addLevelName(TRACE, 'TRACE')
+        logging.addLevelName(TRACE, "TRACE")
         logging.basicConfig(
             stream=sys.stdout,
             level=logging.INFO,

--- a/connect/support/kafka_segments.py
+++ b/connect/support/kafka_segments.py
@@ -117,5 +117,5 @@ def _purge_segments():
         last_accessed = _message_store[identifier]["last_accessed"]
         current_time = time.time() - settings.kafka_segments_purge_timeout
         if last_accessed < current_time:
-            logger.trace(f"Purging message segments with identifier: {identifier}")
+            logger.log(TRACE, f"Purging message segments with identifier: {identifier}")
             del _message_store[identifier]

--- a/connect/support/kafka_segments.py
+++ b/connect/support/kafka_segments.py
@@ -117,5 +117,5 @@ def _purge_segments():
         last_accessed = _message_store[identifier]["last_accessed"]
         current_time = time.time() - settings.kafka_segments_purge_timeout
         if last_accessed < current_time:
-            logger.info(f"Purging message segments with identifier: {identifier}")
+            logger.trace(f"Purging message segments with identifier: {identifier}")
             del _message_store[identifier]

--- a/connect/workflows/core.py
+++ b/connect/workflows/core.py
@@ -110,7 +110,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
 
         logger.log(
             TRACE,
-            f"{self.__class__.__name__}: incoming message type = {type(self.message)}"
+            f"{self.__class__.__name__}: incoming message type = {type(self.message)}",
         )
 
         if hasattr(self.message, "dict"):
@@ -142,7 +142,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         storage_delta = datetime.now() - storage_start
         logger.log(
             TRACE,
-            f" {self.__class__.__name__} persist: stored resource location = {kafka_cb.kafka_result}"
+            f" {self.__class__.__name__} persist: stored resource location = {kafka_cb.kafka_result}",
         )
         total_time = datetime.utcnow() - self.start_time
         message["elapsed_storage_time"] = storage_delta.total_seconds()
@@ -244,7 +244,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
 
         logger.log(
             TRACE,
-            f"{self.__class__.__name__} error: stored resource location = {kafka_cb.kafka_result}"
+            f"{self.__class__.__name__} error: stored resource location = {kafka_cb.kafka_result}",
         )
         message["data_record_location"] = kafka_cb.kafka_result
         error = LFHError(**message).json()

--- a/connect/workflows/core.py
+++ b/connect/workflows/core.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from fastapi import Response
 from httpx import AsyncClient
 from connect.clients.kafka import get_kafka_producer, KafkaCallback
-from connect.config import nats_sync_subject
+from connect.config import nats_sync_subject, TRACE
 from connect.exceptions import LFHError
 from connect.routes.data import LinuxForHealthDataRecordResponse
 from connect.support.encoding import (
@@ -108,8 +108,8 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
             the original object instance in the data field as a byte string
         """
 
-        logger.debug(f"{self.__class__.__name__}: incoming message = {self.message}")
-        logger.debug(
+        logger.log(
+            TRACE,
             f"{self.__class__.__name__}: incoming message type = {type(self.message)}"
         )
 
@@ -140,7 +140,8 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         )
 
         storage_delta = datetime.now() - storage_start
-        logger.debug(
+        logger.log(
+            TRACE,
             f" {self.__class__.__name__} persist: stored resource location = {kafka_cb.kafka_result}"
         )
         total_time = datetime.utcnow() - self.start_time
@@ -150,9 +151,6 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         message["status"] = kafka_cb.kafka_status
 
         response = LinuxForHealthDataRecordResponse(**message).dict()
-        logger.debug(
-            f"{self.__class__.__name__} persist: outgoing message = {response}"
-        )
         self.message = response
 
     @xworkflows.transition("do_transmit")
@@ -224,7 +222,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         :param error: The error message tp be stored in kafka
         :return: The json string for the error message stored in Kafka
         """
-        logger.debug(f"{self.__class__.__name__} error: incoming error = {error}")
+        logger.log(TRACE, f"{self.__class__.__name__} error: incoming error = {error}")
         data_str = json.dumps(self.message, cls=ConnectEncoder)
         data = json.loads(data_str)
 
@@ -244,12 +242,12 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
             on_delivery=kafka_cb.get_kafka_result,
         )
 
-        logger.debug(
+        logger.log(
+            TRACE,
             f"{self.__class__.__name__} error: stored resource location = {kafka_cb.kafka_result}"
         )
         message["data_record_location"] = kafka_cb.kafka_result
         error = LFHError(**message).json()
-        logger.debug(f"{self.__class__.__name__} error: outgoing message = {error}")
         return error
 
     async def run(self, response: Response):
@@ -262,7 +260,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         self.start_time = datetime.utcnow()
 
         try:
-            logger.info(f"Running {self.__class__.__name__}, message={self.message}")
+            logger.log(TRACE, f"Running {self.__class__.__name__}")
             self.validate()
             self.transform()
             await self.persist()

--- a/connect/workflows/fhir.py
+++ b/connect/workflows/fhir.py
@@ -6,8 +6,12 @@ Customizes the base LinuxForHealth workflow definition for FHIR resources.
 import logging
 import xworkflows
 from fhir.resources import construct_fhir_element
+from connect.config import TRACE
 from connect.exceptions import FhirValidationError, MissingFhirResourceType
 from connect.workflows.core import CoreWorkflow
+
+
+logger = logging.getLogger(__name__)
 
 
 class FhirWorkflow(CoreWorkflow):
@@ -26,7 +30,7 @@ class FhirWorkflow(CoreWorkflow):
         raises: MissingFhirResourceType, FhirValidationTypeError
         """
         resource_type = self.message.get("resourceType")
-        logging.debug(f"FhirWorkflow.validate: resource type = {resource_type}")
+        logger.log(TRACE, f"FhirWorkflow.validate: resource type = {resource_type}")
         if resource_type is None:
             raise MissingFhirResourceType()
 
@@ -36,5 +40,3 @@ class FhirWorkflow(CoreWorkflow):
         except LookupError as le:
             logging.exception(le)
             raise FhirValidationError(str(le))
-
-        logging.debug(f"FhirWorkflow.validate: validated resource = {resource_type}")

--- a/logging.yaml
+++ b/logging.yaml
@@ -6,7 +6,7 @@ formatters:
 handlers:
   console:
     class: logging.StreamHandler
-    level: TRACE
+    level: INFO
     formatter: simple
     stream: ext://sys.stdout
 root:
@@ -14,6 +14,6 @@ root:
   handlers: [console]
 loggers:
   connect:
-    level: TRACE
+    level: INFO
   uvicorn:
     level: INFO

--- a/logging.yaml
+++ b/logging.yaml
@@ -6,7 +6,7 @@ formatters:
 handlers:
   console:
     class: logging.StreamHandler
-    level: INFO
+    level: TRACE
     formatter: simple
     stream: ext://sys.stdout
 root:
@@ -14,6 +14,6 @@ root:
   handlers: [console]
 loggers:
   connect:
-    level: INFO
+    level: TRACE
   uvicorn:
     level: INFO


### PR DESCRIPTION
DEBUG logging now looks like:
```
2021-04-23 15:17:02,987 - connect.server_handlers - INFO - Loaded logging configuration from logging.yaml
2021-04-23 15:17:03,059 - connect.clients.nats - DEBUG - Created NATS client for servers = ['tls://localhost:4222']
2021-04-23 15:17:03,059 - connect.clients.nats - DEBUG - Subscribed tls://localhost:4222 to NATS subject EVENTS.sync
2021-04-23 15:17:03,074 - uvicorn.error - INFO - Application startup complete.
2021-04-23 15:17:10,055 - uvicorn.access - INFO - 127.0.0.1:61007 - "POST /fhir/Patient HTTP/1.1" 200
2021-04-23 15:17:21,659 - uvicorn.access - INFO - 127.0.0.1:61009 - "GET /data?dataformat=FHIR-R4_PATIENT&partition=0&offset=0 HTTP/1.1" 200
2021-04-23 15:17:28,604 - uvicorn.access - INFO - 127.0.0.1:61012 - "GET /status HTTP/1.1" 200
```
and TRACE logging now looks like:
```
2021-04-23 15:26:53,948 - connect.server_handlers - INFO - Loaded logging configuration from logging.yaml
2021-04-23 15:26:54,036 - connect.clients.nats - DEBUG - Created NATS client for servers = ['tls://localhost:4222']
2021-04-23 15:26:54,037 - connect.clients.nats - DEBUG - Subscribed tls://localhost:4222 to NATS subject EVENTS.sync
2021-04-23 15:26:54,046 - uvicorn.error - INFO - Application startup complete.
^[[A^[[B^[[B
2021-04-23 15:27:18,656 - connect.workflows.core - TRACE - Running FhirWorkflow
2021-04-23 15:27:18,657 - connect.workflows.fhir - TRACE - FhirWorkflow.validate: resource type = Patient
2021-04-23 15:27:18,769 - connect.workflows.core - TRACE - FhirWorkflow: incoming message type = <class 'fhir.resources.patient.Patient'>
2021-04-23 15:27:19,058 - connect.clients.kafka - TRACE - Produced record to topic FHIR-R4_PATIENT partition [0] @ offset 5
2021-04-23 15:27:19,058 - connect.workflows.core - TRACE -  FhirWorkflow persist: stored resource location = FHIR-R4_PATIENT:0:5
2021-04-23 15:27:19,059 - uvicorn.access - INFO - 127.0.0.1:61076 - "POST /fhir/Patient HTTP/1.1" 200
2021-04-23 15:27:19,061 - connect.clients.nats - TRACE - nats_sync_event_handler: received a message on EVENTS.sync 
2021-04-23 15:27:19,062 - connect.clients.nats - TRACE - nats_sync_event_handler: detected local LFH message, not storing in kafka
2021-04-23 15:27:23,261 - connect.clients.kafka - TRACE - Found message for topic_name - FHIR-R4_PATIENT, partition - 0 and offset - 0. Invoking callback_method - <function _fetch_data_record_cb at 0x10edb8ca0>
2021-04-23 15:27:23,262 - uvicorn.access - INFO - 127.0.0.1:61077 - "GET /data?dataformat=FHIR-R4_PATIENT&partition=0&offset=0 HTTP/1.1" 200
2021-04-23 15:27:26,573 - uvicorn.access - INFO - 127.0.0.1:61080 - "GET /status HTTP/1.1" 200
```