### PR TITLE
Refactor trace logging to support trace method

### DIFF
--- a/connect/clients/kafka.py
+++ b/connect/clients/kafka.py
@@ -15,7 +15,7 @@ from confluent_kafka import (
     TopicPartition,
 )
 from confluent_kafka.admin import AdminClient, NewTopic
-from connect.config import get_settings, kafka_sync_topic, TRACE
+from connect.config import get_settings, kafka_sync_topic
 from connect.exceptions import KafkaMessageNotFoundError, KafkaStorageError
 from threading import Thread
 from typing import Callable, List, Optional
@@ -187,8 +187,7 @@ class ConfluentAsyncKafkaConsumer:
             #     message = combine_segments(msg.value(), self._generate_header_dictionary(msg.headers()))
 
             if message is not None:
-                logger.log(
-                    TRACE,
+                logger.trace(
                     f"Found message for topic_name - {self.topic_name}, partition - {self.partition} "
                     f"and offset - {self.offset}. Invoking callback_method - {callback_method}",
                 )
@@ -287,9 +286,8 @@ class ConfluentAsyncKafkaListener:
             error_code = msg.error().code() if msg and msg.error() else None
             if error_code == KafkaError._PARTITION_EOF:
                 # End of partition event
-                logger.log(
-                    TRACE,
-                    f"Listener: {msg.topic()} [{msg.partition()}] reached end, offset {msg.offset()}",
+                logger.trace(
+                    f"Listener: {msg.topic()} [{msg.partition()}] reached end, offset {msg.offset()}"
                 )
             elif error_code:
                 # other error
@@ -393,8 +391,7 @@ class KafkaCallback:
         else:
             self.kafka_status = "success"
             self.kafka_result = f"{msg.topic()}:{msg.partition()}:{msg.offset()}"
-            logger.log(
-                TRACE,
+            logger.trace(
                 f"Produced record to topic {msg.topic()} "
                 f"partition [{msg.partition()}] @ offset {msg.offset()}",
             )

--- a/connect/clients/nats.py
+++ b/connect/clients/nats.py
@@ -9,7 +9,7 @@ import ssl
 from asyncio import get_running_loop
 from nats.aio.client import Client as NatsClient, Msg
 from connect.clients.kafka import get_kafka_producer, KafkaCallback
-from connect.config import get_settings, nats_sync_subject, kafka_sync_topic, TRACE
+from connect.config import get_settings, nats_sync_subject, kafka_sync_topic
 from connect.support.encoding import decode_to_dict
 from typing import Callable, List, Optional
 
@@ -68,15 +68,12 @@ async def nats_sync_event_handler(msg: Msg):
     subject = msg.subject
     reply = msg.reply
     data = msg.data.decode()
-    logger.log(
-        TRACE, f"nats_sync_event_handler: received a message on {subject} {reply}"
-    )
+    logger.trace(f"nats_sync_event_handler: received a message on {subject} {reply}")
 
     # if the message is from our local LFH, don't store in kafka
     message = json.loads(data)
     if get_settings().connect_lfh_id == message["lfh_id"]:
-        logger.log(
-            TRACE,
+        logger.trace(
             "nats_sync_event_handler: detected local LFH message, not storing in kafka",
         )
         return
@@ -87,8 +84,7 @@ async def nats_sync_event_handler(msg: Msg):
     await kafka_producer.produce_with_callback(
         kafka_sync_topic, data, on_delivery=kafka_cb.get_kafka_result
     )
-    logger.log(
-        TRACE,
+    logger.trace(
         f"nats_sync_event_handler: stored msg in kafka topic {kafka_sync_topic} at {kafka_cb.kafka_result}",
     )
 
@@ -107,8 +103,7 @@ async def nats_sync_event_handler(msg: Msg):
 
     result = await workflow.run(None)
     location = result["data_record_location"]
-    logger.log(
-        TRACE,
+    logger.trace(
         f"nats_sync_event_handler: replayed nats sync message, data record location = {location}",
     )
 

--- a/connect/config.py
+++ b/connect/config.py
@@ -21,8 +21,6 @@ import socket
 host_name = socket.gethostname()
 nats_sync_subject = "EVENTS.sync"
 kafka_sync_topic = "LFH_SYNC"
-# set TRACE log level below DEBUG
-TRACE = 5
 
 
 class Settings(BaseSettings):

--- a/connect/support/kafka_segments.py
+++ b/connect/support/kafka_segments.py
@@ -116,6 +116,7 @@ def _purge_segments():
     for identifier in list(_message_store.keys()):
         last_accessed = _message_store[identifier]["last_accessed"]
         current_time = time.time() - settings.kafka_segments_purge_timeout
+        # trace log
         if last_accessed < current_time:
-            logger.log(TRACE, f"Purging message segments with identifier: {identifier}")
+            logger.trace(f"Purging message segments with identifier: {identifier}")
             del _message_store[identifier]

--- a/connect/workflows/core.py
+++ b/connect/workflows/core.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from fastapi import Response
 from httpx import AsyncClient
 from connect.clients.kafka import get_kafka_producer, KafkaCallback
-from connect.config import nats_sync_subject, TRACE
+from connect.config import nats_sync_subject
 from connect.exceptions import LFHError
 from connect.routes.data import LinuxForHealthDataRecordResponse
 from connect.support.encoding import (
@@ -108,8 +108,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
             the original object instance in the data field as a byte string
         """
 
-        logger.log(
-            TRACE,
+        logger.trace(
             f"{self.__class__.__name__}: incoming message type = {type(self.message)}",
         )
 
@@ -140,8 +139,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         )
 
         storage_delta = datetime.now() - storage_start
-        logger.log(
-            TRACE,
+        logger.trace(
             f" {self.__class__.__name__} persist: stored resource location = {kafka_cb.kafka_result}",
         )
         total_time = datetime.utcnow() - self.start_time
@@ -222,7 +220,7 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         :param error: The error message tp be stored in kafka
         :return: The json string for the error message stored in Kafka
         """
-        logger.log(TRACE, f"{self.__class__.__name__} error: incoming error = {error}")
+        logger.trace(f"{self.__class__.__name__} error: incoming error = {error}")
         data_str = json.dumps(self.message, cls=ConnectEncoder)
         data = json.loads(data_str)
 
@@ -241,9 +239,8 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
             error.json(),
             on_delivery=kafka_cb.get_kafka_result,
         )
-
-        logger.log(
-            TRACE,
+        # trace log
+        logger.trace(
             f"{self.__class__.__name__} error: stored resource location = {kafka_cb.kafka_result}",
         )
         message["data_record_location"] = kafka_cb.kafka_result
@@ -260,7 +257,8 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         self.start_time = datetime.utcnow()
 
         try:
-            logger.log(TRACE, f"Running {self.__class__.__name__}")
+            # trace log
+            logger.trace(f"Running {self.__class__.__name__}")
             self.validate()
             self.transform()
             await self.persist()

--- a/connect/workflows/fhir.py
+++ b/connect/workflows/fhir.py
@@ -6,7 +6,6 @@ Customizes the base LinuxForHealth workflow definition for FHIR resources.
 import logging
 import xworkflows
 from fhir.resources import construct_fhir_element
-from connect.config import TRACE
 from connect.exceptions import FhirValidationError, MissingFhirResourceType
 from connect.workflows.core import CoreWorkflow
 
@@ -30,7 +29,7 @@ class FhirWorkflow(CoreWorkflow):
         raises: MissingFhirResourceType, FhirValidationTypeError
         """
         resource_type = self.message.get("resourceType")
-        logger.log(TRACE, f"FhirWorkflow.validate: resource type = {resource_type}")
+        logger.trace(f"FhirWorkflow.validate: resource type = {resource_type}")
         if resource_type is None:
             raise MissingFhirResourceType()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from connect.server_handlers import add_trace_logging
+
+add_trace_logging()


### PR DESCRIPTION
This PR updates connect's trace logging patch to support logging via `logger.trace`. The trace method is configured during server startup in "server handlers"