### PR TITLE
Connect Settings Does Not Load .env File

### DIFF
--- a/connect/config.py
+++ b/connect/config.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import List
 from datetime import timedelta
 import os
+from os.path import dirname, abspath
 import certifi
 import socket
 
@@ -28,10 +29,8 @@ class Settings(BaseSettings):
     connect application settings
     """
 
-    # First preference to a defined env var 'APPLICATION_CERT_PATH'
-    application_cert_path: str = os.getenv(
-        "APPLICATION_CERT_PATH",
-        os.path.join(Path(__file__).parents[1], "local-config/certs"),
+    application_cert_path: str = os.path.join(
+        Path(__file__).parents[1], "local-config/certs"
     )
     nats_config_path: str = os.path.join(Path(__file__).parents[1], "local-config/nats")
 
@@ -82,6 +81,7 @@ class Settings(BaseSettings):
 
     class Config:
         case_sensitive = False
+        env_file = os.path.join(dirname(dirname(abspath(__file__))), ".env")
 
 
 @lru_cache()


### PR DESCRIPTION
The connect settings class fails to load the local connect/.env file due to missing configuration. This PR updates connect's setting's config class to specify the location of the .env file. The Pydantic framework needs this setting as it relies on python-dotenv to load the file.

This change also allows us to simplify the application_cert_path setting. We no longer need to  "parse" the environment variable in the assignment.

To test I updated main.py and added a print statement for APPLICATION_CERT_PATH

Default Values
```
tdw@dixons-mbp connect % pipenv run connect
Loading .env environment variables...
APPLICATION_CERT_PATH /Users/tdw/projects/lfh/connect/local-config/certs
```

Specify environment variable on command line
```
tdw@dixons-mbp connect % APPLICATION_CERT_PATH=/tmp/certs pipenv run connect
Loading .env environment variables...
APPLICATION_CERT_PATH /tmp/certs
```

Specify environment variable in .env file
```
tdw@dixons-mbp connect % cat .env
# LinuxForHealth Environment Settings
# Supported settings are specified in connect/config.py

APPLICATION_CERT_PATH=/opt/certs

# used with pipenv to support launching from root directory
PYTHONPATH=.
# enable hot reload for local development
UVICORN_RELOAD=True

tdw@dixons-mbp connect % pipenv run connect 
Loading .env environment variables...
APPLICATION_CERT_PATH /opt/certs
```

Reference - [dotenv support](https://pydantic-docs.helpmanual.io/usage/settings/#dotenv-env-support)