### PR TITLE
Added aggregate metrics for timed functions

### DIFF
--- a/connect/routes/status.py
+++ b/connect/routes/status.py
@@ -31,7 +31,8 @@ class StatusResponse(BaseModel):
     is_reload_enabled: bool
     nats_client_status: constr(regex=nats_client_regex)
     kafka_broker_status: constr(regex=status_regex)
-    elapsed_time: float
+    status_response_time: float
+    metrics: dict
 
     class Config:
         schema_extra = {
@@ -41,7 +42,8 @@ class StatusResponse(BaseModel):
                 "is_reload_enabled": False,
                 "nats_client_status": "CONNECTED",
                 "kafka_broker_status": "AVAILABLE",
-                "elapsed_time": 0.080413915000008,
+                "status_response_time": 0.080413915000008,
+                "metrics": {"run": {"total": 0.001, "count": 1, "average": 0.001}},
             }
         }
 
@@ -65,6 +67,9 @@ async def get_status(settings=Depends(get_settings)):
         "kafka_broker_status": await get_service_status(
             settings.kafka_bootstrap_servers
         ),
-        "elapsed_time": time.perf_counter() - start_time,
+        "status_response_time": float(
+            "{:.8f}".format(time.perf_counter() - start_time)
+        ),
+        "metrics": nats.timing_metrics,
     }
     return StatusResponse(**status_fields)

--- a/connect/routes/status.py
+++ b/connect/routes/status.py
@@ -70,6 +70,26 @@ async def get_status(settings=Depends(get_settings)):
         "status_response_time": float(
             "{:.8f}".format(time.perf_counter() - start_time)
         ),
-        "metrics": nats.timing_metrics,
+        "metrics": format_metrics(nats.timing_metrics),
     }
     return StatusResponse(**status_fields)
+
+
+def format_metrics(d: dict) -> dict:
+    """
+    Format the floats in a dict with nested dicts, for display.
+
+    :param d: dict containing floats to format
+    :return: new dict matching the original, except with formatted floats
+    """
+    new = {}
+
+    for key in d:
+        if isinstance(d[key], dict):
+            new[key] = format_metrics(d[key])
+        elif isinstance(d[key], float):
+            new[key] = float("{:.8f}".format(d[key]))
+        else:
+            new[key] = d[key]
+
+    return new

--- a/connect/support/timer.py
+++ b/connect/support/timer.py
@@ -5,8 +5,11 @@ Timer functions for timing LinuxForHealth connect functions.
 """
 import functools
 import inspect
+import json
 import logging
 import time
+from connect.clients import nats
+from connect.support.encoding import ConnectEncoder
 
 
 logger = logging.getLogger(__name__)
@@ -14,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def timer(func):
     """
-    @timer decorator to print the elapsed runtime of the decorated function.
+    @timer decorator to print the elapsed run time of the decorated function.
 
     Whether the function you are decorating is sync or async, you need to await
     the function when you use the @timer decorator.
@@ -30,7 +33,12 @@ def timer(func):
             result = func(*args, **kwargs)
 
         run_time = time.time() - start_time
-        logger.trace(f"{func.__name__}() elapsed time = {run_time:.7f}s")
+
+        nats_client = await nats.get_nats_client()
+        message = {"function": func.__name__, "elapsed_time": run_time}
+        msg_str = json.dumps(message, cls=ConnectEncoder)
+        await nats_client.publish("TIMING", bytearray(msg_str, "utf-8"))
+
         return result
 
     return timer_wrapper

--- a/connect/workflows/core.py
+++ b/connect/workflows/core.py
@@ -3,12 +3,9 @@ core.py
 
 Provides the base LinuxForHealth workflow definition.
 """
-import inspect
 import json
-import functools
 import logging
 import connect.clients.nats as nats
-import time
 import uuid
 import xworkflows
 from datetime import datetime
@@ -24,6 +21,7 @@ from connect.support.encoding import (
     decode_to_str,
     ConnectEncoder,
 )
+from connect.support.timer import timer
 
 
 logger = logging.getLogger(__name__)
@@ -79,29 +77,6 @@ class CoreWorkflow(xworkflows.WorkflowEnabled):
         self.uuid = str(uuid.uuid4())
 
     state = CoreWorkflowDef()
-
-    def timer(func):
-        """
-        Decorator to print the elapsed runtime of the decorated function
-        """
-
-        @functools.wraps(func)
-        async def timer_wrapper(*args, **kwargs):
-            self = args[0]
-            start_time = time.time()
-
-            if inspect.iscoroutinefunction(func):
-                result = await func(*args, **kwargs)
-            else:
-                result = func(*args, **kwargs)
-
-            run_time = time.time() - start_time
-            logger.trace(
-                f"{func.__name__}() id = {self.uuid} elapsed time = {run_time:.7f}s"
-            )
-            return result
-
-        return timer_wrapper
 
     @xworkflows.transition("do_validate")
     @timer

--- a/connect/workflows/fhir.py
+++ b/connect/workflows/fhir.py
@@ -7,6 +7,7 @@ import logging
 import xworkflows
 from fhir.resources import construct_fhir_element
 from connect.exceptions import FhirValidationError, MissingFhirResourceType
+from connect.support.timer import timer
 from connect.workflows.core import CoreWorkflow
 
 
@@ -19,7 +20,7 @@ class FhirWorkflow(CoreWorkflow):
     """
 
     @xworkflows.transition("do_validate")
-    @CoreWorkflow.timer
+    @timer
     def validate(self):
         """
         Overridden to validate the incoming FHIR message by instantiating a fhir.resources

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -4,7 +4,7 @@ Tests the /fhir endpoint
 """
 import asyncio
 import pytest
-from connect.clients import kafka
+from connect.clients import kafka, nats
 from connect.config import get_settings
 from connect.workflows.fhir import FhirWorkflow
 from starlette.responses import Response
@@ -161,6 +161,7 @@ async def test_fhir_post(
     with monkeypatch.context() as m:
         m.setattr(kafka, "ConfluentAsyncKafkaProducer", mock_async_kafka_producer)
         m.setattr(FhirWorkflow, "synchronize", AsyncMock())
+        m.setattr(nats, "get_nats_client", AsyncMock(return_value=AsyncMock()))
 
         async with async_test_client as ac:
             # remove external server setting
@@ -219,6 +220,7 @@ async def test_fhir_post_with_transmit(
         m.setattr(kafka, "ConfluentAsyncKafkaProducer", mock_async_kafka_producer)
         m.setattr(FhirWorkflow, "transmit", mock_workflow_transmit)
         m.setattr(FhirWorkflow, "synchronize", AsyncMock())
+        m.setattr(nats, "get_nats_client", AsyncMock(return_value=AsyncMock()))
 
         async with async_test_client as ac:
             ac._transport.app.dependency_overrides[get_settings] = lambda: settings
@@ -248,6 +250,7 @@ async def test_fhir_post_endpoints(
     with monkeypatch.context() as m:
         m.setattr(kafka, "ConfluentAsyncKafkaProducer", mock_async_kafka_producer)
         m.setattr(FhirWorkflow, "synchronize", AsyncMock())
+        m.setattr(nats, "get_nats_client", AsyncMock(return_value=AsyncMock()))
 
         async with async_test_client as ac:
             # remove external server setting

--- a/tests/routes/test_status.py
+++ b/tests/routes/test_status.py
@@ -30,8 +30,9 @@ async def test_status_get(async_test_client, settings, monkeypatch):
 
             actual_json = actual_response.json()
             assert "application_version" in actual_json
-            assert "elapsed_time" in actual_json
-            assert actual_json["elapsed_time"] > 0.0
+            assert "status_response_time" in actual_json
+            assert actual_json["status_response_time"] > 0.0
+            assert "metrics" in actual_json
 
             expected = {
                 "application": "connect.asgi:app",
@@ -39,6 +40,7 @@ async def test_status_get(async_test_client, settings, monkeypatch):
                 "is_reload_enabled": False,
                 "nats_client_status": "CONNECTED",
                 "kafka_broker_status": "AVAILABLE",
-                "elapsed_time": actual_json["elapsed_time"],
+                "status_response_time": actual_json["status_response_time"],
+                "metrics": actual_json["metrics"],
             }
             assert actual_json == expected

--- a/tests/workflows/test_core.py
+++ b/tests/workflows/test_core.py
@@ -104,7 +104,7 @@ async def test_manual_flow(
 
         await workflow.synchronize()
         assert workflow.state.name == "sync"
-        nats_mock.publish.assert_called_once()
+        assert nats_mock.publish.call_count == 6
 
 
 @pytest.mark.asyncio
@@ -124,11 +124,13 @@ async def test_manual_flow_transmit_disabled(
     :param mock_httpx_client: Mock HTTPX Client fixture
     """
     workflow.start_time = datetime.datetime.utcnow()
+    nats_mock = AsyncMock()
 
     with monkeypatch.context() as m:
         m.setattr(core, "get_kafka_producer", Mock(return_value=AsyncMock()))
         m.setattr(core, "KafkaCallback", kafka_callback)
         m.setattr(core, "AsyncClient", mock_httpx_client)
+        m.setattr(nats, "get_nats_client", AsyncMock(return_value=nats_mock))
 
         await workflow.validate()
         assert workflow.state.name == "validate"


### PR DESCRIPTION
Changes:
- Added NATS-based metric aggregation for each function timed with `@timer`
- Removed CoreWorkflow `@timer` in favor of support/timer.py `@timer`
- Added 'metrics' object to /status that shows the total time, msg count and average time for each function being timed
