### PR TITLE
Added JSON support for Decimal fields

### DIFF
--- a/connect/support/encoding.py
+++ b/connect/support/encoding.py
@@ -5,6 +5,7 @@ encoding.py
  LinuxForHealth messages.
 """
 import base64
+import decimal
 import json
 from json import JSONEncoder
 import datetime
@@ -17,6 +18,8 @@ class ConnectEncoder(JSONEncoder):
     Provides additional encoding support for the following types:
     - UUID fields
     - date, datetime, and time fields
+    - byte fields
+    - Decimal fields
     """
 
     def default(self, o: Any) -> Any:
@@ -30,6 +33,8 @@ class ConnectEncoder(JSONEncoder):
             return str(o)
         elif isinstance(o, bytes):
             return base64.b64encode(o).decode()
+        elif isinstance(o, decimal.Decimal):
+            return float(o)
         else:
             return super().default(o)
 

--- a/tests/support/test_encoding_utils.py
+++ b/tests/support/test_encoding_utils.py
@@ -16,6 +16,7 @@ import pytest
 import datetime
 import uuid
 import copy
+import decimal
 
 
 @pytest.fixture(scope="module")
@@ -34,6 +35,10 @@ def dictionary_data():
             2021, 3, 23, hour=15, minute=10, second=12
         ),
         "uuid": uuid.UUID("d897987e-133b-4236-996d-554c012ee8d9"),
+        "location": {
+            "lat": decimal.Decimal("37.421925"),
+            "long": decimal.Decimal("-122.0841293"),
+        },
     }
 
 
@@ -49,6 +54,8 @@ def decoded_dictionary_data(dictionary_data):
         "start_date_time"
     ].isoformat()
     copied_dictionary["uuid"] = str(copied_dictionary["uuid"])
+    copied_dictionary["location"]["lat"] = float(copied_dictionary["location"]["lat"])
+    copied_dictionary["location"]["long"] = float(copied_dictionary["location"]["long"])
     return copied_dictionary
 
 
@@ -57,7 +64,7 @@ def encoded_dictionary_data():
     """
     The encoded representation of the dictionary data fixture.
     """
-    return '{"resourceType": "Patient", "id": "001", "id01": 100, "id02": 900.123, "active": true, "start_date": "2021-03-23", "start_date_time": "2021-03-23T15:10:12", "uuid": "d897987e-133b-4236-996d-554c012ee8d9"}'
+    return '{"resourceType": "Patient", "id": "001", "id01": 100, "id02": 900.123, "active": true, "start_date": "2021-03-23", "start_date_time": "2021-03-23T15:10:12", "uuid": "d897987e-133b-4236-996d-554c012ee8d9", "location": {"lat": 37.421925, "long": -122.0841293}}'
 
 
 def test_encode_from_dict(dictionary_data):
@@ -66,7 +73,7 @@ def test_encode_from_dict(dictionary_data):
     :param dictionary_data: The dictionary data fixture used as the encoding input.
     """
     encoded_data = encode_from_dict(dictionary_data)
-    expected_data = "eyJyZXNvdXJjZVR5cGUiOiAiUGF0aWVudCIsICJpZCI6ICIwMDEiLCAiaWQwMSI6IDEwMCwgImlkMDIiOiA5MDAuMTIzLCAiYWN0aXZlIjogdHJ1ZSwgInN0YXJ0X2RhdGUiOiAiMjAyMS0wMy0yMyIsICJzdGFydF9kYXRlX3RpbWUiOiAiMjAyMS0wMy0yM1QxNToxMDoxMiIsICJ1dWlkIjogImQ4OTc5ODdlLTEzM2ItNDIzNi05OTZkLTU1NGMwMTJlZThkOSJ9"
+    expected_data = "eyJyZXNvdXJjZVR5cGUiOiAiUGF0aWVudCIsICJpZCI6ICIwMDEiLCAiaWQwMSI6IDEwMCwgImlkMDIiOiA5MDAuMTIzLCAiYWN0aXZlIjogdHJ1ZSwgInN0YXJ0X2RhdGUiOiAiMjAyMS0wMy0yMyIsICJzdGFydF9kYXRlX3RpbWUiOiAiMjAyMS0wMy0yM1QxNToxMDoxMiIsICJ1dWlkIjogImQ4OTc5ODdlLTEzM2ItNDIzNi05OTZkLTU1NGMwMTJlZThkOSIsICJsb2NhdGlvbiI6IHsibGF0IjogMzcuNDIxOTI1LCAibG9uZyI6IC0xMjIuMDg0MTI5M319"
     assert expected_data == encoded_data
 
 
@@ -115,7 +122,7 @@ def test_decode_to_dict(decoded_dictionary_data):
     Validates decode_to_dict with mock data.
     :param: decoded_dictionary_data: The decoded dictionary fixture used as the "expected result"
     """
-    actual_data = "eyJyZXNvdXJjZVR5cGUiOiAiUGF0aWVudCIsICJpZCI6ICIwMDEiLCAiaWQwMSI6IDEwMCwgImlkMDIiOiA5MDAuMTIzLCAiYWN0aXZlIjogdHJ1ZSwgInN0YXJ0X2RhdGUiOiAiMjAyMS0wMy0yMyIsICJzdGFydF9kYXRlX3RpbWUiOiAiMjAyMS0wMy0yM1QxNToxMDoxMiIsICJ1dWlkIjogImQ4OTc5ODdlLTEzM2ItNDIzNi05OTZkLTU1NGMwMTJlZThkOSJ9"
+    actual_data = "eyJyZXNvdXJjZVR5cGUiOiAiUGF0aWVudCIsICJpZCI6ICIwMDEiLCAiaWQwMSI6IDEwMCwgImlkMDIiOiA5MDAuMTIzLCAiYWN0aXZlIjogdHJ1ZSwgInN0YXJ0X2RhdGUiOiAiMjAyMS0wMy0yMyIsICJzdGFydF9kYXRlX3RpbWUiOiAiMjAyMS0wMy0yM1QxNToxMDoxMiIsICJ1dWlkIjogImQ4OTc5ODdlLTEzM2ItNDIzNi05OTZkLTU1NGMwMTJlZThkOSIsICJsb2NhdGlvbiI6IHsibGF0IjogMzcuNDIxOTI1LCAibG9uZyI6IC0xMjIuMDg0MTI5M319"
     decoded_data = decode_to_dict(actual_data)
     assert decoded_dictionary_data == decoded_data
 


### PR DESCRIPTION
This solution adds support for decimal.Decimal types in the ConnectEncoder. 

Tested with an Observation resource that does not parse properly without this change.