### PR TITLE
Added NATS-based HTTP transmit retry capability

### DIFF
--- a/connect/clients/nats.py
+++ b/connect/clients/nats.py
@@ -117,6 +117,8 @@ async def subscribe(client: NatsClient, subject: str, callback: Callable, server
 async def nats_sync_event_handler(msg: Msg):
     """
     Callback for NATS 'nats_sync_subject' messages
+
+    :param msg: a message delivered from the NATS server
     """
     subject = msg.subject
     reply = msg.reply
@@ -164,6 +166,8 @@ async def nats_sync_event_handler(msg: Msg):
 def nats_timing_event_handler(msg: Msg):
     """
     Callback for NATS TIMING messages - calculates the average run time for any function timed with @timer.
+
+    :param msg: a message delivered from the NATS server
     """
     data = msg.data.decode()
 
@@ -185,6 +189,8 @@ def nats_timing_event_handler(msg: Msg):
 async def nats_retransmit_event_handler(msg: Msg):
     """
     Callback for NATS 'nats_retransmit_subject' messages
+
+    :param msg: a message delivered from the NATS server
     """
     subject = msg.subject
     reply = msg.reply
@@ -200,6 +206,10 @@ async def nats_retransmit_event_handler(msg: Msg):
 async def do_retransmit(message: dict, queue_pos: int):
     """
     Process messages from NATS or the nats_retransmit_queue.
+
+    :param message: the LFH message containing the data to retransmit
+    :param queue_pos: the position of the message in the queue.  queue_pos will be -1 if
+        the message has not yet been queued or 0 <= queue_pos < len(nats_retransmit_queue).
     """
     global nats_retransmit_queue
     settings = get_settings()

--- a/connect/clients/nats.py
+++ b/connect/clients/nats.py
@@ -8,8 +8,6 @@ import json
 import logging
 import os
 import ssl
-import time
-import threading
 from asyncio import get_running_loop
 from datetime import datetime
 from httpx import AsyncClient

--- a/connect/config.py
+++ b/connect/config.py
@@ -21,6 +21,7 @@ import ssl
 
 host_name = socket.gethostname()
 nats_sync_subject = "EVENTS.sync"
+nats_retransmit_subject = "EVENTS.retransmit"
 kafka_sync_topic = "LFH_SYNC"
 
 
@@ -69,11 +70,15 @@ class Settings(BaseSettings):
     kafka_listener_timeout: float = 1.0
     kafka_topics_timeout: float = 0.5
 
+    # nats
     nats_servers: List[str] = ["tls://nats-server:4222"]
     nats_sync_subscribers: List[str] = []
     nats_allow_reconnect: bool = True
     nats_max_reconnect_attempts: int = 10
     nats_nk_file: str = "nats-server.nk"
+    nats_enable_retransmit: bool = True
+    nats_retransmit_loop_interval: int = 10
+    nats_retransmit_max_retries: int = 20
 
     class Config:
         case_sensitive = False

--- a/connect/config.py
+++ b/connect/config.py
@@ -77,7 +77,7 @@ class Settings(BaseSettings):
     nats_max_reconnect_attempts: int = 10
     nats_nk_file: str = "nats-server.nk"
     nats_enable_retransmit: bool = True
-    nats_retransmit_loop_interval: int = 10
+    nats_retransmit_loop_interval_secs: int = 10
     nats_retransmit_max_retries: int = 20
 
     # ipfs-cluster

--- a/connect/routes/fhir.py
+++ b/connect/routes/fhir.py
@@ -90,6 +90,7 @@ async def post_fhir_data(
             transmit_server=transmit_server,
             do_sync=True,
             operation="POST",
+            do_retransmit=settings.nats_enable_retransmit,
         )
 
         # enable the transmit workflow step if defined


### PR DESCRIPTION
Includes:
- Added produce of NATS message in the case of an HTTP transmit error
- Added NATS subscriber that retries the message when received then queues the message for further retries until max retries (or -1 for infinite)
- Added a loop that checks a queue for retry entries and, if present, sends them to be retried again
- Added config.py entries:
    nats_enable_retransmit: bool = True
    nats_retransmit_loop_interval_secs: int = 10   (seconds between loops through the retry queue)
    nats_retransmit_max_retries: int = 20     (or -1 for infinite retries)
    