### PR TITLE
Created multi-arch IPFS images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     container_name: ipfs-cluster-0
     networks:
       - main
-    image: ipfs/ipfs-cluster:latest
+    image: linuxforhealth/ipfs-cluster:v0.14.0
     depends_on:
       - ipfs-node-0
     environment:
@@ -67,7 +67,7 @@ services:
     container_name: ipfs-node-0
     networks:
       - main
-    image: ipfs/go-ipfs:latest
+    image: linuxforhealth/go-ipfs:release-v0.9.1
     ports:
       - "4001:4001"
       - "8080:8080"

--- a/local-config/ipfs/README.md
+++ b/local-config/ipfs/README.md
@@ -18,3 +18,98 @@ To change the IPFS cluster secret (32-bit hex-encoded string), run the following
 ```shell
 openssl rand -hex 32
 ```
+
+## Build the IPFS multi-arch images
+LinuxForHealth uses ipfs/go-ipfs and ipfs/ipfs-cluster docker images.  However, these images are only available on Docker Hub as amd64 images.  Follow the instructions below to build multi-arch images that support amd64, s390x and arm64.  `docker buildx` does not work for s390x builds, so build each image separately on amd64, s390x and arm64 machines and use `docker manifest` to create the multi-arch images.
+
+### Build go-ipfs
+
+#### Clone the repo and check out a release branch
+```shell
+git clone https://github.com/ipfs/go-ipfs.git
+cd go-ipfs
+git checkout release-v0.9.1
+```
+
+#### Build, tag and push the amd64 image
+On your amd64 machine:
+```shell
+docker build -t linuxforhealth/go-ipfs:release-v0.9.1-amd64 .
+docker push linuxforhealth/go-ipfs:release-v0.9.1-amd64
+```
+
+#### Build, tag and push the arm64 image
+On your arm64 device:
+```shell
+docker build -t linuxforhealth/go-ipfs:release-v0.9.1-arm64 .
+docker push linuxforhealth/go-ipfs:release-v0.9.1-arm64
+```
+
+#### Build, tag and push the s390x image
+On your s390x machine, first edit Dockerfile and add s390x to the [list of supported architectures](https://github.com/ipfs/go-ipfs/blob/e9b1e2d6fb916a342d0d013a3db7b88145ae5eb5/Dockerfile#L37) for tini:
+```shell
+"amd64" | "armhf" | "arm64" | "s390x")
+```
+then build, tag and push the s390x image:
+```shell
+docker build -t linuxforhealth/go-ipfs:release-v0.9.1-s390x .
+docker push linuxforhealth/go-ipfs:release-v0.9.1-s390x
+```
+
+#### Create the multi-arch image
+Use `docker manifest` to create the multi-arch image for all 3 platforms and push it:
+```shell
+docker manifest create \
+linuxforhealth/go-ipfs:release-v0.9.1 \
+--amend linuxforhealth/go-ipfs:release-v0.9.1-s390x \
+--amend linuxforhealth/go-ipfs:release-v0.9.1-amd64 \
+--amend linuxforhealth/go-ipfs:release-v0.9.1-arm64
+
+docker manifest push linuxforhealth/go-ipfs:release-v0.9.1 --purge
+```
+
+### Build ipfs-cluster
+
+#### Clone the repo and check out a tagged release
+```shell
+git clone https://github.com/ipfs/ipfs-cluster.git
+cd ipfs-cluster
+git checkout v0.14.0
+```
+
+#### Build, tag and push the amd64 image
+On your amd64 machine:
+```shell
+docker build -t linuxforhealth/ipfs-cluster:v0.14.0-amd64 .
+docker push linuxforhealth/ipfs-cluster:v0.14.0-amd64
+```
+
+#### Build, tag and push the arm64 image
+On your arm64 device:
+```shell
+docker build -t linuxforhealth/ipfs-cluster:v0.14.0-arm64 .
+docker push linuxforhealth/ipfs-cluster:v0.14.0-arm64
+```
+
+#### Build, tag and push the s390x image
+On your s390x machine, first edit Dockerfile and add s390x to the [list of supported architectures](https://github.com/ipfs/ipfs-cluster/blob/0c01079eca925f7b62ad1984e02c6811093484b1/Dockerfile#L16) for tini:
+```shell
+"amd64" | "armhf" | "arm64" | "s390x")
+```
+then build, tag and push the s390x image:
+```shell
+docker build -t linuxforhealth/ipfs-cluster:v0.14.0-s390x .
+docker push linuxforhealth/ipfs-cluster:v0.14.0-s390x
+```
+
+#### Create the multi-arch image
+Use `docker manifest` to create the multi-arch image for all 3 platforms and push it:
+```shell
+docker manifest create \
+linuxforhealth/ipfs-cluster:v0.14.0 \
+--amend linuxforhealth/ipfs-cluster:v0.14.0-s390x \
+--amend linuxforhealth/ipfs-cluster:v0.14.0-amd64 \
+--amend linuxforhealth/ipfs-cluster:v0.14.0-arm64
+
+docker manifest push linuxforhealth/ipfs-cluster:v0.14.0 --purge
+```

--- a/local-config/ipfs/README.md
+++ b/local-config/ipfs/README.md
@@ -25,6 +25,7 @@ LinuxForHealth uses ipfs/go-ipfs and ipfs/ipfs-cluster docker images.  However, 
 ### Build go-ipfs
 
 #### Clone the repo and check out a release branch
+On each platform clone the repo and check out the correct branch for the release:
 ```shell
 git clone https://github.com/ipfs/go-ipfs.git
 cd go-ipfs
@@ -46,7 +47,7 @@ docker push linuxforhealth/go-ipfs:release-v0.9.1-arm64
 ```
 
 #### Build, tag and push the s390x image
-On your s390x machine, first edit Dockerfile and add s390x to the [list of supported architectures](https://github.com/ipfs/go-ipfs/blob/e9b1e2d6fb916a342d0d013a3db7b88145ae5eb5/Dockerfile#L37) for tini:
+On your s390x machine, first edit the Dockerfile and add s390x to the [list of supported architectures](https://github.com/ipfs/go-ipfs/blob/e9b1e2d6fb916a342d0d013a3db7b88145ae5eb5/Dockerfile#L37) for tini:
 ```shell
 "amd64" | "armhf" | "arm64" | "s390x")
 ```
@@ -71,6 +72,7 @@ docker manifest push linuxforhealth/go-ipfs:release-v0.9.1 --purge
 ### Build ipfs-cluster
 
 #### Clone the repo and check out a tagged release
+On each platform clone the repo and check out the correct tag for the release:
 ```shell
 git clone https://github.com/ipfs/ipfs-cluster.git
 cd ipfs-cluster
@@ -92,7 +94,7 @@ docker push linuxforhealth/ipfs-cluster:v0.14.0-arm64
 ```
 
 #### Build, tag and push the s390x image
-On your s390x machine, first edit Dockerfile and add s390x to the [list of supported architectures](https://github.com/ipfs/ipfs-cluster/blob/0c01079eca925f7b62ad1984e02c6811093484b1/Dockerfile#L16) for tini:
+On your s390x machine, first edit the Dockerfile and add s390x to the [list of supported architectures](https://github.com/ipfs/ipfs-cluster/blob/0c01079eca925f7b62ad1984e02c6811093484b1/Dockerfile#L16) for tini:
 ```shell
 "amd64" | "armhf" | "arm64" | "s390x")
 ```

--- a/platforms/s390x/docker-compose.yml
+++ b/platforms/s390x/docker-compose.yml
@@ -48,7 +48,7 @@ services:
     container_name: ipfs-cluster-0
     networks:
       - main
-    image: ipfs/ipfs-cluster:latest
+    image: linuxforhealth/ipfs-cluster:v0.14.0
     depends_on:
       - ipfs-node-0
     environment:
@@ -66,7 +66,7 @@ services:
     container_name: ipfs-node-0
     networks:
       - main
-    image: ipfs/go-ipfs:latest
+    image: linuxforhealth/go-ipfs:release-v0.9.1
     ports:
       - "4001:4001"
       - "8080:8080"


### PR DESCRIPTION
Changes include:
- Created multi-arch docker images for go-ipfs and ipfs-cluster and pushed these to Docker Hub
   https://hub.docker.com/repository/docker/linuxforhealth/go-ipfs
   https://hub.docker.com/repository/docker/linuxforhealth/ipfs-cluster
- Updated Dockerfiles to use these new images
- Added doc sections for building the images