### PR TITLE
Transmission Attributes Support

### DIFF
--- a/connect/routes/data.py
+++ b/connect/routes/data.py
@@ -42,6 +42,7 @@ class LinuxForHealthDataRecordResponse(BaseModel):
     transmit_date: Optional[datetime.datetime]
     elapsed_transmit_time: Optional[float]
     elapsed_total_time: Optional[float]
+    transmission_attributes: Optional[str]
 
 
 @router.get("")

--- a/tests/routes/test_x12.py
+++ b/tests/routes/test_x12.py
@@ -7,7 +7,6 @@ Tests the /x12 endpoints
 import pytest
 from connect.clients import kafka, nats
 from connect.config import get_settings
-from connect.workflows.fhir import FhirWorkflow
 from unittest.mock import AsyncMock
 
 
@@ -59,7 +58,6 @@ async def test_x12_post(
     """
     with monkeypatch.context() as m:
         m.setattr(kafka, "ConfluentAsyncKafkaProducer", mock_async_kafka_producer)
-        m.setattr(FhirWorkflow, "synchronize", AsyncMock())
         m.setattr(nats, "get_nats_client", AsyncMock(return_value=AsyncMock()))
 
         async with async_test_client as ac:

--- a/tests/workflows/test_core.py
+++ b/tests/workflows/test_core.py
@@ -95,14 +95,17 @@ async def test_manual_flow(
         assert workflow.message["status"] == "success"
 
         workflow.transmit_server = "https://external-server.com/data"
+        workflow.transmission_attributes["tenant_id"] = "MyTenant"
         response = Response()
         await workflow.transmit(response)
         assert workflow.state.name == "transmit"
         assert workflow.message["transmit_date"] is not None
         assert workflow.message["elapsed_transmit_time"] > 0
+        assert len(workflow.transmission_attributes) == 2
+        assert workflow.transmission_attributes["tenant_id"] == "MyTenant"
+        assert "content-length" in workflow.transmission_attributes
         assert workflow.use_response is True
         assert response.headers["LinuxForHealth-MessageId"] is not None
-
         await workflow.synchronize()
         assert workflow.state.name == "sync"
         assert nats_mock.publish.call_count == 6


### PR DESCRIPTION
This PR adds support for "transmission attributes". Transmission attributes are additional data elements defined as key-values pair which accompany a data payload sent to an external system. Within the HTTP/S protocol, transmission attributes are "HTTP headers".

Changes include:

* Updated the LinuxForHealth metadata record to include a transmission_attributes field. The field is a base64 encoded string.
* Added a utility to "scrub" transmission attributes prior to model assignment, to ensure that "secret" fields are not included.
* Added a transmission_attribute instance attribute to the core workflow
* Updated the core workflow's persist and transmit step to support transmission_attributes
* Updated existing core workflow unit test to verify transmission_attributes
* Removed an unrelated FHIR fixture from the x12 endpoint test.

closes #249 