### PR TITLE
Added flag for non-standard fhir servers

### DIFF
--- a/connect/config.py
+++ b/connect/config.py
@@ -49,7 +49,10 @@ class Settings(BaseSettings):
     connect_logging_config_path: str = "logging.yaml"
     # external FHIR server URL or None
     # Example: 'https://fhiruser:change-password@localhost:9443/fhir-server/api/v4'
-    connect_external_fhir_server: str = None
+    connect_external_fhir_server: str = (
+        "https://fhiruser:change-password@localhost:9443/fhir-server/api/v4"
+    )
+    connect_generate_fhir_server_url: bool = True
     connect_rate_limit: str = "5/second"
     connect_timing_enabled: bool = False
 

--- a/connect/routes/fhir.py
+++ b/connect/routes/fhir.py
@@ -82,7 +82,9 @@ async def post_fhir_data(
     transmission_attributes = None
     if settings.connect_external_fhir_server:
         resource_type = request_data["resourceType"]
-        transmit_server = settings.connect_external_fhir_server + "/" + resource_type
+        transmit_server = settings.connect_external_fhir_server
+        if settings.connect_generate_fhir_server_url:
+            transmit_server += "/" + resource_type
         transmission_attributes = {k: v for k, v in request.headers.items()}
 
     try:
@@ -97,13 +99,6 @@ async def post_fhir_data(
             do_retransmit=settings.nats_enable_retransmit,
             transmission_attributes=transmission_attributes,
         )
-
-        # enable the transmit workflow step if defined
-        if settings.connect_external_fhir_server:
-            resource_type = request_data["resourceType"]
-            workflow.transmit_server = (
-                settings.connect_external_fhir_server + "/" + resource_type
-            )
 
         result = await workflow.run(response)
 


### PR DESCRIPTION
Set connect_generate_fhir_server_url to False in config.py if running from the command line or set CONNECT_GENERATE_FHIR_SERVER_URL to false in docker-compose.yml, in the connect env section.

Signed-off-by: ccorley <ccorley@us.ibm.com>