### PR TITLE
Simplified response handling

### DIFF
--- a/connect/clients/ipfs.py
+++ b/connect/clients/ipfs.py
@@ -87,7 +87,7 @@ class IPFSClient:
         Note: IPFS Node Peers are managed implicitly by IPFS Cluster.
 
         :returns: Tuple containing an HTTP response code and JSON with IPFS
-                  Cluster and managed Nodes information. Returns reponse_code
+                  Cluster and managed Nodes information. Returns response_code
                   and None if a non 200 response code is returned from IPFS
                   Cluster
         """

--- a/connect/clients/nats.py
+++ b/connect/clients/nats.py
@@ -261,7 +261,7 @@ async def do_retransmit(message: dict, queue_pos: int):
             + f"after {message['retransmit_count']} retries"
         )
     except Exception as ex:
-        logger.trace(f"do_retransmit: exception {ex}")
+        logger.trace(f"do_retransmit: exception {type(ex)}")
         if queue_pos == -1:
             nats_retransmit_queue.append(message)
             logger.trace(f"do_retransmit: queued message for retransmitter()")

--- a/connect/clients/nats.py
+++ b/connect/clients/nats.py
@@ -175,10 +175,9 @@ async def nats_sync_event_handler(msg: Msg):
         do_retransmit=settings.nats_enable_retransmit,
     )
 
-    results = await workflow.run()
-    location = results["message"]["data_record_location"]
+    result = await workflow.run()
     logger.trace(
-        f"nats_sync_event_handler: replayed nats sync message, data record location = {location}",
+        f"nats_sync_event_handler: replayed nats sync message, result = {result}",
     )
 
 

--- a/connect/routes/fhir.py
+++ b/connect/routes/fhir.py
@@ -107,9 +107,7 @@ async def post_fhir_data(
             do_retransmit=settings.nats_enable_retransmit,
             transmission_attributes={k: v for k, v in request.headers.items()},
         )
-        results = await workflow.run()
-
-        return workflow.set_response(response, results)
+        return await workflow.run()
     except Exception as ex:
         raise HTTPException(status_code=500, detail=str(ex))
 

--- a/connect/routes/fhir.py
+++ b/connect/routes/fhir.py
@@ -109,7 +109,7 @@ async def post_fhir_data(
         )
         return await workflow.run()
     except Exception as ex:
-        raise HTTPException(status_code=500, detail=str(ex))
+        raise HTTPException(status_code=500, detail=ex)
 
 
 def validate(resource_type: str, request_data: dict) -> dict:

--- a/connect/routes/x12.py
+++ b/connect/routes/x12.py
@@ -50,7 +50,7 @@ async def post_x12_data(
                     data_format=data_format,
                 )
                 results = await workflow.run()
-                x12_results.append(results["lfh_message"])
+                x12_results.append(results)
             return x12_results
     except ValidationError as ve:
         raise HTTPException(status_code=422, detail=ve)

--- a/connect/workflows/core.py
+++ b/connect/workflows/core.py
@@ -294,7 +294,7 @@ class CoreWorkflow:
             msg = await self.error(ex)
             raise Exception(msg)
 
-    def _set_response(self, transmit_result: dict) -> Union[Response, Dict]:
+    def _set_response(self, transmit_result: List[Dict]) -> Union[Response, Dict]:
         """
         Return the result of handling the message.  The result from calling _set_response will be either
         self.message (Dict) or a Response instance containing the body and status code from the transmit results,

--- a/tests/routes/test_fhir.py
+++ b/tests/routes/test_fhir.py
@@ -3,7 +3,6 @@ test_fhir.py
 Tests the /fhir endpoint
 """
 import asyncio
-import json
 import pytest
 from connect.clients import kafka, nats
 from connect.config import get_settings

--- a/tests/workflows/test_core.py
+++ b/tests/workflows/test_core.py
@@ -115,8 +115,7 @@ async def test_run_flow(
         m.setattr(core, "AsyncClient", mock_httpx_client)
         m.setattr(nats, "get_nats_client", AsyncMock(return_value=AsyncMock()))
 
-        result = await workflow.run()
-        actual_value = workflow.set_response(Response(), result)
+        actual_value = await workflow.run()
         assert actual_value["consuming_endpoint_url"] == "http://localhost:5000/data"
         assert actual_value["creation_date"] is not None
         assert (


### PR DESCRIPTION
Changes:
- Updated the CoreWorkflow run() method to call _set_response() (now an internal-only method) and return a new Response object, obviating the need to pass in a response object
- Fixed an exception caused by not being able to serialize httpx.* exceptions like httpx.ConnectError (retransmit still worked, even with the exception, but it was generating unnecessary LFHError instances in kafka)
- Improved exception messaging to display the type of the exception where we can't get a string for an exception
- Fixed some typos and general cleanup

Signed-off-by: ccorley <ccorley@us.ibm.com>