### PR TITLE
Added postgres to default LinuxForHealth profile

### DIFF
--- a/.env
+++ b/.env
@@ -33,8 +33,6 @@ X12_READER_BUFFER_SIZE=1024000
 # SQL Server
 SAPASSWORD="Super@Duper_Password20"
 
-# Postgres Container Variables
+# Postgres
 POSTGRES_USER=lfh_user
 POSTGRES_PASSWORD=change_password
-POSTGRES_DB=lfh_database
-PGPORT=5432

--- a/.env
+++ b/.env
@@ -37,3 +37,4 @@ SAPASSWORD="Super@Duper_Password20"
 POSTGRES_USER=lfh_user
 POSTGRES_PASSWORD=change_password
 POSTGRES_DB=lfh_database
+PGPORT=5432

--- a/.env
+++ b/.env
@@ -32,3 +32,8 @@ X12_READER_BUFFER_SIZE=1024000
 ## MSFT FHIR Container Variables
 # SQL Server
 SAPASSWORD="Super@Duper_Password20"
+
+# Postgres Container Variables
+POSTGRES_USER=lfh_user
+POSTGRES_PASSWORD=change_password
+POSTGRES_DB=lfh_database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,12 +87,12 @@ services:
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
-      PGPORT: ${PGPORT}
+      POSTGRES_DB: lfh_database
+      PGPORT: 5432
     volumes:
       - postgres-data:/var/lib/postgresql/data/
     ports:
-      - ${PGPORT}:${PGPORT}
+      - 5432:5432
   ibm-fhir:
     profiles: ["fhir", "deployment"]
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,11 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+      PGPORT: ${PGPORT}
     volumes:
       - postgres-data:/var/lib/postgresql/data/
+    ports:
+      - ${PGPORT}:${PGPORT}
   ibm-fhir:
     profiles: ["fhir", "deployment"]
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,16 @@ services:
       - ./local-config/ipfs/volumes/ipfs-node-0:/data/ipfs
       - ./local-config/ipfs/private-ipfs-network/swarm.key:/data/ipfs/swarm.key
       - ./local-config/ipfs/private-ipfs-network/init.sh:/usr/local/bin/start_ipfs
+  postgres:
+    # See https://hub.docker.com/_/postgres/ for config info, e.g. how to run
+    # initialization scripts using an image derived from the official image.
+    image: postgres:14.1-alpine3.14
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data/
   ibm-fhir:
     profiles: ["fhir", "deployment"]
     networks:
@@ -144,3 +154,6 @@ services:
       ETHEREUM_CONTRACT_ADDRESS: "0x7Bad280884c907bBf3955c21351ce41122aB88eB"
     ports:
       - "5100:5100"
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
Added a postgres container to the default LinuxForHealth profile:
- docker-compose.yml postgres params are set in .env
- a volume persists the DB contents
- init scripts can be executed by deriving a new image from the official postgres image and copying the scripts to /docker-entrypoint-initdb.d in the Dockerfile (see: https://hub.docker.com/_/postgres/)

Persistence tested via this simple test:
```
1. Start the connect default profile:
docker-compose up -d
2. Exec into the postgres container:
docker-compose run postgres bash
3. Enter interactive mode to run commands against the database:
psql --host=postgres --username=lfh_user --dbname=lfh_database
3. Verify that no tables exist:
\d
4. Create a table:
CREATE TABLE lfh_table(name TEXT); CREATE TABLE
5. Check that the table exists:
\d
6. Exit the container
\q
exit
7. Stop the postgres container and remove the container:
docker stop connect_postgres_1
docker container prune
8. Start the postgres container
docker-compose up -d postgres
9. Exec into the postgres container:
docker-compose run postgres bash
10. Enter interactive mode to run commands against the database:
psql --host=postgres --username=lfh_user --dbname=lfh_database
11. Verify that lfh_table exists:
\d
```


Signed-off-by: ccorley <ccorley@us.ibm.com>