### PR TITLE
Added an application-level sync message for clients

### DIFF
--- a/connect/config.py
+++ b/connect/config.py
@@ -20,6 +20,7 @@ import ssl
 host_name = socket.gethostname()
 nats_sync_subject = "EVENTS.sync"
 nats_retransmit_subject = "EVENTS.retransmit"
+nats_app_sync_subject = "EVENTS.app_sync"
 kafka_sync_topic = "LFH_SYNC"
 
 


### PR DESCRIPTION
Added EVENTS.app_sync event to allow a local LinuxForHealth client to listen for all sync events in the network, without having to make connections to all NATS servers in the network.

Also, restructured the nats.py subscriber code around local subscriber setup vs a list of servers to subscribe to.

**Testing**
Tested by temporarily adding a subscriber to LinuxForHealth connect via the following code in clients/nats.py:

In create_nats_subscribers(), added this line:
```
await start_local_subscriber(nats_app_sync_subject, nats_app_sync_event_handler)
```

Added this callback:
```
async def nats_app_sync_event_handler(msg: Msg):
    """
    Callback for NATS 'nats_app_sync_subject' messages.

    :param msg: a message delivered from the NATS server
    """
    subject = msg.subject
    reply = msg.reply
    data = msg.data.decode()
    logger.trace(f"nats_app_sync_event_handler: received a message on {subject} {reply}")
```

The result, after sending a FHIR message to LinuxForHealth:
```
2021-11-23 08:22:20,762 - connect.clients.nats - DEBUG - Subscribed tls://localhost:4222 to NATS subject EVENTS.app_sync
2021-11-23 08:22:26,764 - connect.clients.nats - TRACE - nats_app_sync_event_handler: received a message on EVENTS.app_sync 
```

Signed-off-by: ccorley <ccorley@us.ibm.com>